### PR TITLE
Document NeoVim version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This is for people who love the concept of Obsidian -- a simple, markdown-based 
 
 ### Requirements
 
-The plugin [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) is required, and if you want completion features (recommended) you'll also need [ripgrep](https://github.com/BurntSushi/ripgrep) to be installed and on your `$PATH`.
+- A nightly build of NeoVim (this plugin uses `vim.fs`).
+- The [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) plugin.
+- If you want completion features (recommended) you'll also need [ripgrep](https://github.com/BurntSushi/ripgrep) to be installed and on your `$PATH`.
 See [ripgrep#installation](https://github.com/BurntSushi/ripgrep) for install options.
 
 ### Install


### PR DESCRIPTION
Hello! I gave this plugin a try recently, but it errored at start up. The issue is that the plugin uses the `vim.fs` APIs, which are not yet available on the latest nvim release (0.7).

This commit updates the README to make this requirement clear. Feel free to close or modify however you see fit, of course. I'm just opening this as a heads up.

The plugin looks really nice!