### PR TITLE
Fix bug with `:ObsidianOpen`

### DIFF
--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -120,7 +120,7 @@ end
 client.vault = function(self)
   local vault_indicator_folder = ".obsidian"
   local dirs = self.dir:parents()
-  table.insert(dirs, self.dir:absolute())
+  table.insert(dirs, 0, self.dir:absolute())
   for _, dir in pairs(dirs) do
     ---@type Path
     ---@diagnostic disable-next-line: assign-type-mismatch


### PR DESCRIPTION
We need to consider the `dir` first, before considering the parents. So need to insert it at the beginning, not at the end.