### PR TITLE
Follow Markdown Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added `:ObsidianFollowLink` and companion function `util.cursor_on_markdown_link`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensured vault directory along with optional notes and daily notes subdirectories are added to vim's `path` so you can `gf` to files in those directories.
-- Added `:ObsidianFollowLink` command with exposed functionality to check if the cursor is presently on a markdown link so the user can passthrough functionality to `gf`
 
 ## [v1.6.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.6.0) - 2022-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensured vault directory along with optional notes and daily notes subdirectories are added to vim's `path` so you can `gf` to files in those directories.
+- Added `:ObsidianFollowLink` command with exposed functionality to check if the cursor is presently on a markdown link so the user can passthrough functionality to `gf`
 
 ## [v1.6.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.6.0) - 2022-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Added `:ObsidianFollowLink` and companion function `util.cursor_on_markdown_link`
 
 ### Added
 
+- Added `:ObsidianFollowLink` and companion function `util.cursor_on_markdown_link`
 - Added `:ObsidianLink` and `:ObsidianLinkNew` commands.
 
 ## [v1.6.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.6.1) - 2022-10-17

--- a/README.md
+++ b/README.md
@@ -21,15 +21,12 @@ Built for people who love the concept of Obsidian -- a simple, markdown-based no
 - `:ObsidianNew` to create a new note.
   This command has one optional argument: the title of the new note.
 - `:ObsidianSearch` to search for notes in your vault using [ripgrep](https://github.com/BurntSushi/ripgrep) with [fzf.vim](https://github.com/junegunn/fzf.vim) or [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).
-<<<<<<< HEAD
   This command has one optional argument: a search query to start with.
 - `:ObsidianLink` to link an in-line visual selection of text to a note.
   This command has one optional argument: the ID, path, or alias of the note to link to. If not given, the selected text will be used to find the note with a matching ID, path, or alias.
 - `:ObsidianLinkNew` to create a new note and link it to an in-line visual selection of text.
   This command has one optional argument: the title of the new note. If not given, the selected text will be used as the title.
-=======
 - `:ObsidianFollowLink` to open a note or create a new note in your vault
->>>>>>> 9720ba9 (Updated README to reflect changes)
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ Built for people who love the concept of Obsidian -- a simple, markdown-based no
 - `:ObsidianNew` to create a new note.
   This command has one optional argument: the title of the new note.
 - `:ObsidianSearch` to search for notes in your vault using [ripgrep](https://github.com/BurntSushi/ripgrep) with [fzf.vim](https://github.com/junegunn/fzf.vim) or [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).
+<<<<<<< HEAD
   This command has one optional argument: a search query to start with.
 - `:ObsidianLink` to link an in-line visual selection of text to a note.
   This command has one optional argument: the ID, path, or alias of the note to link to. If not given, the selected text will be used to find the note with a matching ID, path, or alias.
 - `:ObsidianLinkNew` to create a new note and link it to an in-line visual selection of text.
   This command has one optional argument: the title of the new note. If not given, the selected text will be used as the title.
+=======
+- `:ObsidianFollowLink` to open a note or create a new note in your vault
+>>>>>>> 9720ba9 (Updated README to reflect changes)
 
 ## Setup
 
@@ -195,4 +199,20 @@ require("obsidian").setup({
     return out
   end,
 })
+```
+
+#### Mapping ObsidianFollowLink with passthrough
+```lua
+vim.keymap.set(
+    "n",
+    "gf",
+    function()
+        if require('obsidian').util.cursor_on_markdown_link() then
+            return "<cmd>ObsidianFollowLink<CR>"
+        else
+            return "gf"
+        end
+    end,
+    { noremap = false, expr = true}
+)
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Built for people who love the concept of Obsidian -- a simple, markdown-based no
   This command has one optional argument: the ID, path, or alias of the note to link to. If not given, the selected text will be used to find the note with a matching ID, path, or alias.
 - `:ObsidianLinkNew` to create a new note and link it to an in-line visual selection of text.
   This command has one optional argument: the title of the new note. If not given, the selected text will be used as the title.
-- `:ObsidianFollowLink` to open a note or create a new note in your vault
+- `:ObsidianFollowLink` to follow a note reference under the cursor.
 
 ## Setup
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -174,6 +174,7 @@ command.search = function(client, data)
   end
 end
 
+<<<<<<< HEAD
 command.link_new = function(client, data)
   local _, csrow, cscol, _ = unpack(vim.fn.getpos "'<")
   local _, cerow, cecol, _ = unpack(vim.fn.getpos "'>")
@@ -292,6 +293,38 @@ command.complete_args = function(client, arg_lead, cmd_line, cursor_pos)
   end
 
   return completions
+=======
+--- Follow link under cursor.
+---
+---@param client obsidian.Client
+command.follow = function(client, _)
+  local open, close = util.cursor_on_markdown_link()
+  local current_line = vim.api.nvim_get_current_line()
+
+  if open == nil or close == nil then
+      return nil
+  end
+
+  local note_name = current_line:sub(open + 2, close - 1)
+  local path = client.dir
+  
+  if not note_name:match("%.md") then
+    note_name = note_name .. ".md"
+  end
+  
+  if note_name:match("|[^%]]*") then
+    note_name = note_name:sub(1, note_name:find('|'))
+  end
+
+  if note_name:match("/") then
+
+  elseif client.opts.notes_subdir ~= nil then
+    path = path / client.opts.notes_subdir
+  end
+
+  path = path / note_name
+  vim.api.nvim_command("e " .. tostring(path))
+>>>>>>> 375867b (Custom implementation for following links)
 end
 
 local commands = {
@@ -301,8 +334,12 @@ local commands = {
   ObsidianNew = { func = command.new, opts = { nargs = "?" } },
   ObsidianBacklinks = { func = command.backlinks, opts = { nargs = 0 } },
   ObsidianSearch = { func = command.search, opts = { nargs = "?" } },
+<<<<<<< HEAD
   ObsidianLink = { func = command.link, opts = { nargs = "?", range = true }, complete = command.complete_args },
   ObsidianLinkNew = { func = command.link_new, opts = { nargs = "?", range = true } },
+=======
+  ObsidianFollowLink = {func = command.follow, opts = {nargs = 0 } },
+>>>>>>> 375867b (Custom implementation for following links)
 }
 
 ---Register all commands.

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -330,8 +330,10 @@ command.follow = function(client, _)
       on_insert = function(entry)
         note_dir = Path:new(entry .. "/" .. note_name)
         if note_dir:is_dir() then
-          local _, note = pcall(Note.from_file, entry .. "/" .. note_name, client.dir)
-          table.insert(notes, note.path)
+          local ok, note = pcall(Note.from_file, entry .. "/" .. note_name, client.dir)
+          if ok then
+            table.insert(notes, note.path)
+          end
         end
       end
     })

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -311,7 +311,7 @@ command.follow = function(client, _)
   local path = client.dir
 
   if note_name:match "|[^%]]*" then
-    note_name = note_name:sub(1, note_name:find "|")
+    note_name = note_name:sub(1, note_name:find "|" - 1)
   end
 
   if not note_name:match "%.md" then

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -309,36 +309,34 @@ command.follow = function(client, _)
 
   local note_name = current_line:sub(open + 2, close - 1)
   local path = client.dir
-  
-  if note_name:match("|[^%]]*") then
-    note_name = note_name:sub(1, note_name:find('|'))
+
+  if note_name:match "|[^%]]*" then
+    note_name = note_name:sub(1, note_name:find "|")
   end
 
-  if not note_name:match("%.md") then
+  if not note_name:match "%.md" then
     note_name = note_name .. ".md"
   end
-  
 
   local notes = {}
 
-  if not note_name:match("/") then
+  if not note_name:match "/" then
     scan.scan_dir(vim.fs.normalize(tostring(client.dir)), {
       hidden = false,
       add_dirs = false,
       only_dirs = true,
       respect_gitignore = true,
       on_insert = function(entry)
-        note_dir = Path:new(entry .. "/" .. note_name)
+        local note_dir = Path:new(entry .. "/" .. note_name)
         if note_dir:is_dir() then
           local ok, note = pcall(Note.from_file, entry .. "/" .. note_name, client.dir)
           if ok then
             table.insert(notes, note.path)
           end
         end
-      end
+      end,
     })
   end
-
 
   if #notes < 1 then
     path = path / note_name
@@ -347,7 +345,7 @@ command.follow = function(client, _)
     path = notes[1]
     vim.api.nvim_command("e " .. tostring(path))
   else
-    echo.err("Multiple notes with this name exist")
+    echo.err "Multiple notes with this name exist"
     return
   end
 end
@@ -361,7 +359,7 @@ local commands = {
   ObsidianSearch = { func = command.search, opts = { nargs = "?" } },
   ObsidianLink = { func = command.link, opts = { nargs = "?", range = true }, complete = command.complete_args },
   ObsidianLinkNew = { func = command.link_new, opts = { nargs = "?", range = true } },
-  ObsidianFollowLink = {func = command.follow, opts = {nargs = 0 } },
+  ObsidianFollowLink = { func = command.follow, opts = { nargs = 0 } },
 }
 
 ---Register all commands.

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -327,11 +327,11 @@ command.follow = function(client, _)
       only_dirs = true,
       respect_gitignore = true,
       on_insert = function(entry)
-        local note_dir = Path:new(entry .. "/" .. note_name)
-        if note_dir:is_dir() then
-          local ok, note = pcall(Note.from_file, entry .. "/" .. note_name, client.dir)
+        local note_path = Path:new(entry .. "/" .. note_name)
+        if note_path:is_file() then
+          local ok, _ = pcall(Note.from_file, note_path, client.dir)
           if ok then
-            table.insert(notes, note.path)
+            table.insert(notes, note_path)
           end
         end
       end,

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -292,6 +292,7 @@ command.complete_args = function(client, arg_lead, cmd_line, cursor_pos)
   end
 
   return completions
+end
 
 --- Follow link under cursor.
 ---
@@ -319,7 +320,6 @@ command.follow = function(client, _)
   
 
   local notes = {}
-  local count = 1
 
   if not note_name:match("/") then
     scan.scan_dir(vim.fs.normalize(tostring(client.dir)), {
@@ -331,7 +331,8 @@ command.follow = function(client, _)
           note_dir = entry .. "/" .. note_name
           ok, _ = os.rename(note_dir, note_dir)
           if ok then
-            table.insert(notes, note_dir)
+            local _, note = pcall(Note.from_file, entry .. "/" .. note_name, client.dir)
+            table.insert(notes, note.path)
           end
         end
     })
@@ -342,21 +343,6 @@ command.follow = function(client, _)
     path = path / note_name
     vim.api.nvim_command("e " .. tostring(path))
   elseif #notes == 1 then
-    path = notes[1]
-    vim.api.nvim_command("e " .. tostring(path))
-  else
-    echo.err("Multiple notes with this name exist")
-    return
-  end
-end
-
-  path = path / note_name
-  vim.api.nvim_command("e " .. tostring(path))
-
-  if table.getn(notes) < 1 then
-    path = path / note_name
-    vim.api.nvim_command("e " .. tostring(path))
-  elseif table.getn(notes) == 1 then
     path = notes[1]
     vim.api.nvim_command("e " .. tostring(path))
   else

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -174,7 +174,6 @@ command.search = function(client, data)
   end
 end
 
-<<<<<<< HEAD
 command.link_new = function(client, data)
   local _, csrow, cscol, _ = unpack(vim.fn.getpos "'<")
   local _, cerow, cecol, _ = unpack(vim.fn.getpos "'>")
@@ -293,7 +292,6 @@ command.complete_args = function(client, arg_lead, cmd_line, cursor_pos)
   end
 
   return completions
-=======
 --- Follow link under cursor.
 ---
 ---@param client obsidian.Client
@@ -339,11 +337,8 @@ command.follow = function(client, _)
     })
   end
 
-<<<<<<< HEAD
   path = path / note_name
   vim.api.nvim_command("e " .. tostring(path))
->>>>>>> 375867b (Custom implementation for following links)
-=======
 
   if table.getn(notes) < 1 then
     path = path / note_name
@@ -355,8 +350,6 @@ command.follow = function(client, _)
     echo.err("Multiple notes with this name exist")
     return
   end
-    
->>>>>>> 2875a23 (Follow link now matches against existing files)
 end
 
 local commands = {
@@ -366,12 +359,9 @@ local commands = {
   ObsidianNew = { func = command.new, opts = { nargs = "?" } },
   ObsidianBacklinks = { func = command.backlinks, opts = { nargs = 0 } },
   ObsidianSearch = { func = command.search, opts = { nargs = "?" } },
-<<<<<<< HEAD
   ObsidianLink = { func = command.link, opts = { nargs = "?", range = true }, complete = command.complete_args },
   ObsidianLinkNew = { func = command.link_new, opts = { nargs = "?", range = true } },
-=======
   ObsidianFollowLink = {func = command.follow, opts = {nargs = 0 } },
->>>>>>> 375867b (Custom implementation for following links)
 }
 
 ---Register all commands.

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -328,13 +328,12 @@ command.follow = function(client, _)
       only_dirs = true,
       respect_gitignore = true,
       on_insert = function(entry)
-          note_dir = entry .. "/" .. note_name
-          ok, _ = os.rename(note_dir, note_dir)
-          if ok then
-            local _, note = pcall(Note.from_file, entry .. "/" .. note_name, client.dir)
-            table.insert(notes, note.path)
-          end
+        note_dir = Path:new(entry .. "/" .. note_name)
+        if note_dir:is_dir() then
+          local _, note = pcall(Note.from_file, entry .. "/" .. note_name, client.dir)
+          table.insert(notes, note.path)
         end
+      end
     })
   end
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -304,7 +304,8 @@ command.follow = function(client, _)
   local current_line = vim.api.nvim_get_current_line()
 
   if open == nil or close == nil then
-    return nil
+    echo.err "Cursor is not on a reference!"
+    return
   end
 
   local note_name = current_line:sub(open + 2, close - 1)

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -270,19 +270,19 @@ end
 -- @return integer, integer
 util.cursor_on_markdown_link = function()
   local current_line = vim.api.nvim_get_current_line()
-  local cur_row, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
-  
+  local _, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
+
   local current_line_lh = current_line:sub(0, cur_col + 2)
-  
+
   -- Search for two open brackets followed by any number of non-open bracket
   -- characters nor close bracket characters
-  local open = current_line_lh:find("%[%[[^%[%]]*%]?%]?$") 
+  local open = current_line_lh:find "%[%[[^%[%]]*%]?%]?$"
   local close = current_line:find("%]%]", cur_col)
 
   if open == nil or close == nil then
-      return nil, nil
-  else 
-      return open, close
+    return nil, nil
+  else
+    return open, close
   end
 end
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -266,4 +266,21 @@ util.table_length = function(x)
   return n
 end
 
+-- Determines if cursor is currently inside markdown link
+-- @return integer, integer
+util.cursor_on_markdown_link = function()
+  local current_line = vim.api.nvim_get_current_line()
+  local cur_row, cur_col = vim.api.nvim_win_get_cursor(0)
+  local current_line_lh = current_line:sub(1, cur_col)
+  
+  local open = current_line_lh:find("%[%[[^%[]") 
+  local close = current_line:find("%]%]", cur_col)
+
+  if open == nil or close == nil then
+      return nil, nil
+  else 
+      return open, close
+  end
+end
+
 return util

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -273,8 +273,9 @@ util.cursor_on_markdown_link = function()
   local cur_row, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
   local current_line_lh = current_line:sub(1, cur_col)
   
-    print(cur_row, cur_col)
-  local open = current_line_lh:find("%[%[[^%[]") 
+  -- Search for two open brackets followed by any number of non-open bracket
+  -- characters nor close bracket characters
+  local open = current_line_lh:find("%[%[[^%[%]]*%]?%]?$") 
   local close = current_line:find("%]%]", cur_col)
 
   if open == nil or close == nil then

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -271,7 +271,13 @@ end
 util.cursor_on_markdown_link = function()
   local current_line = vim.api.nvim_get_current_line()
   local cur_row, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
-  local current_line_lh = current_line:sub(1, cur_col)
+  
+  -- This fixes an issue where the link was unfollowable while the cursor
+  -- was on the first bracket and at the beginning of the line
+  local current_line_lh = current_line
+  if cur_col - 2 >= 2 then
+    local current_line_lh = current_line:sub(1, cur_col)
+  end
   
   -- Search for two open brackets followed by any number of non-open bracket
   -- characters nor close bracket characters

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -270,9 +270,10 @@ end
 -- @return integer, integer
 util.cursor_on_markdown_link = function()
   local current_line = vim.api.nvim_get_current_line()
-  local cur_row, cur_col = vim.api.nvim_win_get_cursor(0)
+  local cur_row, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
   local current_line_lh = current_line:sub(1, cur_col)
   
+    print(cur_row, cur_col)
   local open = current_line_lh:find("%[%[[^%[]") 
   local close = current_line:find("%]%]", cur_col)
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -272,12 +272,7 @@ util.cursor_on_markdown_link = function()
   local current_line = vim.api.nvim_get_current_line()
   local cur_row, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
   
-  -- This fixes an issue where the link was unfollowable while the cursor
-  -- was on the first bracket and at the beginning of the line
-  local current_line_lh = current_line
-  if cur_col - 2 >= 2 then
-    local current_line_lh = current_line:sub(1, cur_col)
-  end
+  local current_line_lh = current_line:sub(0, cur_col + 2)
   
   -- Search for two open brackets followed by any number of non-open bracket
   -- characters nor close bracket characters


### PR DESCRIPTION
#24 

Everything is working as far as my testing could tell. I'm slightly concerned that I over engineered the solution a bit, though. I wanted to make sure that the links could find the file regardless of whether it was in a sub-directory or not plus account for functionality if the link contained a complete reference to the path of the  note. The solution I landed on was to just scan the entire vault directory looking for a matching note and routing there, unless the note name was ambiguous. 

