### PR TITLE
Fix blocking Neovim UI during :ObsidianOpen (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed bug with `Note.from_lines` where the given path would be modified in place to be relative to the root, which caused a bug in `:ObsidianFollowLink`.
 - Completion for creating new notes via nvim-cmp is now aware of daily notes, so when you start typing todays date in the form of YYYY-MM-DD, you get a "Create new" completion option for today's daily note if it doesn't exist yet.
+- Fixed bug where `:ObsidianOpen` blocked the NeoVim UI on Linux.
 
 ## [v1.6.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.6.1) - 2022-10-17
 


### PR DESCRIPTION
The fundamental problem was that `os.execute` blocks, by design. This PR switches the invocation of the external Obsidian application to be asynchronous/non-blocking via a Plenary Job.

Fixes #47 , but I don't have access to a Mac right now and need some help testing on macOS.