### PR TITLE
Fix URL encoding for space characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug with `Note.from_lines` where the given path would be modified in place to be relative to the root, which caused a bug in `:ObsidianFollowLink`.
 - Completion for creating new notes via nvim-cmp is now aware of daily notes, so when you start typing todays date in the form of YYYY-MM-DD, you get a "Create new" completion option for today's daily note if it doesn't exist yet.
 - Fixed bug where `:ObsidianOpen` blocked the NeoVim UI on Linux.
+- Fixed URL encoding of space characters for better compatibility with external applications.
 
 ## [v1.6.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.6.1) - 2022-10-17
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -51,7 +51,12 @@ util.urlencode = function(str)
   local url = str
   url = url:gsub("\n", "\r\n")
   url = url:gsub("([^%w _%%%-%.~])", char_to_hex)
-  url = url:gsub(" ", "+")
+
+  -- Spaces in URLs are always safely encoded with `%20`, but not always safe
+  -- with `+`. For example, `+` in a query param's value will be interpreted
+  -- as a literal plus-sign if the decoder is using JavaScript's `decodeURI`
+  -- function.
+  url = url:gsub(" ", "%%20")
   return url
 end
 

--- a/test/obsidian/util_spec.lua
+++ b/test/obsidian/util_spec.lua
@@ -2,7 +2,7 @@ local util = require "obsidian.util"
 
 describe("obsidian.util", function()
   it("should correctly URL-encode a path", function()
-    assert.equals(util.urlencode [[~/Library/Foo Bar.md]], [[~%2FLibrary%2FFoo+Bar.md]])
+    assert.equals(util.urlencode [[~/Library/Foo Bar.md]], [[~%2FLibrary%2FFoo%20Bar.md]])
   end)
   it("should match case of key to prefix", function()
     assert.equals(util.match_case("Foo", "foo"), "Foo")


### PR DESCRIPTION
I ran into this one while using #56 , but this should improve general compatibility for anything that needs URI encoding. Turns out, encoding URIs in Lua is kind of a pain. Didn't know that. But this seems to do the trick for all the edge cases I personally have.

TLDR here is that `%20` is always a safe encoding for a space character, regardless of where it is in the raw URL string, but `+` is interpreted as a literal if it's in a query param value.