### PR TITLE
feat: ObsidianYesterday command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `:ObsidianLink` and `:ObsidianLinkNew` commands.
 - Added configuration option `disable_frontmatter` for frontmatter disabling
 - Added line-navigation to `:ObsidianOpen` via the Obsidian Advanced URI plugin
+- Added `:ObsidianYesterday` command to open/create the previous working day daily note
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Built for people who love the concept of Obsidian -- a simple, markdown-based no
 
 - `:ObsidianBacklinks` for getting a location list of references to the current buffer.
 - `:ObsidianToday` to create a new daily note.
+- `:ObsidianYesterday` to open (eventually creating) the daily note for the previous working day.
 - `:ObsidianOpen` to open a note in the Obsidian app.
   This command has one optional argument: the ID, path, or alias of the note to open. If not given, the note corresponding to the current buffer is opened.
 - `:ObsidianNew` to create a new note.

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -54,6 +54,15 @@ command.today = function(client, _)
   vim.api.nvim_command("e " .. tostring(note.path))
 end
 
+---Create (or open) yesterday daily note.
+---
+---@param client obsidian.Client
+---@param _ table
+command.yesterday = function(client, _)
+  local note = client:yesterday()
+  vim.api.nvim_command("e " .. tostring(note.path))
+end
+
 ---Create a new note.
 ---
 ---@param client obsidian.Client
@@ -373,6 +382,7 @@ end
 local commands = {
   ObsidianCheck = { func = command.check, opts = { nargs = 0 } },
   ObsidianToday = { func = command.today, opts = { nargs = 0 } },
+  ObsidianYesterday = { func = command.yesterday, opts = { nargs = 0 } },
   ObsidianOpen = { func = command.open, opts = { nargs = "?" }, complete = command.complete_args },
   ObsidianNew = { func = command.new, opts = { nargs = "?" } },
   ObsidianBacklinks = { func = command.backlinks, opts = { nargs = 0 } },

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -54,7 +54,7 @@ command.today = function(client, _)
   vim.api.nvim_command("e " .. tostring(note.path))
 end
 
----Create (or open) yesterday daily note.
+---Create (or open) the daily note from the last weekday.
 ---
 ---@param client obsidian.Client
 ---@param _ table

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -271,7 +271,7 @@ client.today = function(self)
   return note
 end
 
----Open (or create) yesterday daily note.
+---Open (or create) the daily note from the last weekday.
 ---
 ---@return obsidian.Note
 client.yesterday = function(self)

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -271,6 +271,28 @@ client.today = function(self)
   return note
 end
 
+---Open (or create) yesterday daily note.
+---
+---@return obsidian.Note
+client.yesterday = function(self)
+  ---@type string
+  ---@diagnostic disable-next-line: assign-type-mismatch
+  local today = os.time()
+  local yesterday = obsidian.util.working_day_before(today)
+  local id = tostring(os.date("%Y-%m-%d", yesterday))
+  local alias = tostring(os.date("%B %-d, %Y", yesterday))
+  local path = self:daily_note_path(id)
+
+  -- Create Note object and save if it doesn't already exist.
+  local note = obsidian.note.new(id, { alias }, { "daily-notes" }, path)
+  if not note:exists() then
+    note:save()
+    echo.info("Created note " .. tostring(note.id) .. " at " .. tostring(note.path))
+  end
+
+  return note
+end
+
 ---Resolve the query to a single note.
 ---
 ---@param query string

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -298,8 +298,8 @@ end
 -- @return boolean
 util.is_working_day = function(time)
   local is_saturday = (os.date("%w", time) == 5)
-  local is_sunday   = (os.date("%w", time) == 6)
-  return not(is_saturday or is_sunday)
+  local is_sunday = (os.date("%w", time) == 6)
+  return not (is_saturday or is_sunday)
 end
 
 -- Determines The working day before a given time
@@ -308,7 +308,7 @@ end
 --
 -- @return time
 util.working_day_before = function(time)
-  local previous_day = time - (24*60*60)
+  local previous_day = time - (24 * 60 * 60)
   if util.is_working_day(previous_day) then
     return previous_day
   else

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -291,4 +291,29 @@ util.cursor_on_markdown_link = function()
   end
 end
 
+-- Determines if the given date is a working day (not weekend)
+--
+-- @param time a Time
+--
+-- @return boolean
+util.is_working_day = function(time)
+  local is_saturday = (os.date("%w", time) == 5)
+  local is_sunday   = (os.date("%w", time) == 6)
+  return not(is_saturday or is_sunday)
+end
+
+-- Determines The working day before a given time
+--
+-- @param time a Time
+--
+-- @return time
+util.working_day_before = function(time)
+  local previous_day = time - (24*60*60)
+  if util.is_working_day(previous_day) then
+    return previous_day
+  else
+    return util.working_day_before(previous_day)
+  end
+end
+
 return util

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -297,8 +297,8 @@ end
 --
 -- @return boolean
 util.is_working_day = function(time)
-  local is_saturday = (os.date("%w", time) == 5)
-  local is_sunday = (os.date("%w", time) == 6)
+  local is_saturday = (os.date("%w", time) == "6")
+  local is_sunday = (os.date("%w", time) == "0")
   return not (is_saturday or is_sunday)
 end
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -302,7 +302,7 @@ util.is_working_day = function(time)
   return not (is_saturday or is_sunday)
 end
 
--- Determines The working day before a given time
+-- Determines the last working day before a given time
 --
 -- @param time a Time
 --


### PR DESCRIPTION
This PR adds a command to open (and eventually create) the daily note for the previous working day (I called it `ObsidianYesterday` for the sake of brevity).

It does so by going back to the first working day (read: week day) before the current day. The rest of the logic is the same as `ObsidianToday`.