### PR TITLE
Fixed small bug in note.from_lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug where `:ObsidianOpen` blocked the NeoVim UI on Linux.
 - Fixed URL encoding of space characters for better compatibility with external applications.
 - Made more robust to unexpected types in frontmatter.
+- Fixed edge case where frontmatter consisting of exactly one empty field would raise an exception.
 
 ## [v1.6.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.6.1) - 2022-10-17
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -209,6 +209,9 @@ note.from_lines = function(lines, path, root)
   if #frontmatter_lines > 0 then
     local frontmatter = table.concat(frontmatter_lines, "\n")
     local ok, data = pcall(yaml.loads, frontmatter)
+    if type(data) == 'string' then
+      data = {data = nil}
+    end
     if ok then
       for k, v in pairs(data) do
         if k == "id" then

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -210,7 +210,7 @@ note.from_lines = function(lines, path, root)
     local frontmatter = table.concat(frontmatter_lines, "\n")
     local ok, data = pcall(yaml.loads, frontmatter)
     if type(data) == 'string' then
-      data = {data = nil}
+      data = {}
     end
     if ok then
       for k, v in pairs(data) do
@@ -296,29 +296,27 @@ note.frontmatter_lines = function(self, eol, frontmatter)
   local new_lines = { "---" }
 
   local frontmatter_ = frontmatter and frontmatter or self:frontmatter()
-  for _, line in
-    ipairs(yaml.dumps_lines(frontmatter_, function(a, b)
-      local a_idx = nil
-      local b_idx = nil
-      for i, k in ipairs { "id", "aliases", "tags" } do
-        if a == k then
-          a_idx = i
-        end
-        if b == k then
-          b_idx = i
-        end
+  for _, line in ipairs(yaml.dumps_lines(frontmatter_, function(a, b)
+    local a_idx = nil
+    local b_idx = nil
+    for i, k in ipairs { "id", "aliases", "tags" } do
+      if a == k then
+        a_idx = i
       end
-      if a_idx ~= nil and b_idx ~= nil then
-        return a_idx < b_idx
-      elseif a_idx ~= nil then
-        return true
-      elseif b_idx ~= nil then
-        return false
-      else
-        return a < b
+      if b == k then
+        b_idx = i
       end
-    end))
-  do
+    end
+    if a_idx ~= nil and b_idx ~= nil then
+      return a_idx < b_idx
+    elseif a_idx ~= nil then
+      return true
+    elseif b_idx ~= nil then
+      return false
+    else
+      return a < b
+    end
+  end)) do
     table.insert(new_lines, line)
   end
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -209,7 +209,7 @@ note.from_lines = function(lines, path, root)
   if #frontmatter_lines > 0 then
     local frontmatter = table.concat(frontmatter_lines, "\n")
     local ok, data = pcall(yaml.loads, frontmatter)
-    if type(data) == 'string' then
+    if type(data) == "string" then
       data = {}
     end
     if ok then
@@ -298,27 +298,29 @@ note.frontmatter_lines = function(self, eol, frontmatter)
   local new_lines = { "---" }
 
   local frontmatter_ = frontmatter and frontmatter or self:frontmatter()
-  for _, line in ipairs(yaml.dumps_lines(frontmatter_, function(a, b)
-    local a_idx = nil
-    local b_idx = nil
-    for i, k in ipairs { "id", "aliases", "tags" } do
-      if a == k then
-        a_idx = i
+  for _, line in
+    ipairs(yaml.dumps_lines(frontmatter_, function(a, b)
+      local a_idx = nil
+      local b_idx = nil
+      for i, k in ipairs { "id", "aliases", "tags" } do
+        if a == k then
+          a_idx = i
+        end
+        if b == k then
+          b_idx = i
+        end
       end
-      if b == k then
-        b_idx = i
+      if a_idx ~= nil and b_idx ~= nil then
+        return a_idx < b_idx
+      elseif a_idx ~= nil then
+        return true
+      elseif b_idx ~= nil then
+        return false
+      else
+        return a < b
       end
-    end
-    if a_idx ~= nil and b_idx ~= nil then
-      return a_idx < b_idx
-    elseif a_idx ~= nil then
-      return true
-    elseif b_idx ~= nil then
-      return false
-    else
-      return a < b
-    end
-  end)) do
+    end))
+  do
     table.insert(new_lines, line)
   end
 


### PR DESCRIPTION
If a note had frontmatter consisting of exactly one empty field, `yaml.loads` would return that field as a string rather than a table, causing an exception in `note.from_lines`.