### PR TITLE
Adding support for fzf-lua in search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for [fzf-lua](https://github.com/ibhagwan/fzf-lua) as one of the possible fallbacks for the `:ObsidianSearch` command.
 - Added `:ObsidianFollowLink` and companion function `util.cursor_on_markdown_link`
 - Added `:ObsidianLink` and `:ObsidianLinkNew` commands.
 - Added configuration option `disable_frontmatter` for frontmatter disabling

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Plug 'hrsh7th/nvim-cmp'
 Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
 Plug 'junegunn/fzf.vim'
 
+" (optional) another alternative for the :ObsidianSearch command:
+Plug 'ibhagwan/fzf-lua'
+
 " (optional) for :ObsidianSearch command if you prefer this over fzf.vim:
 Plug 'nvim-telescope/telescope.nvim'
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -187,7 +187,7 @@ command.search = function(client, data)
     if data.args:len() > 0 then
       fzf_lua.grep { cwd = tostring(client.dir), search = data.args }
     else
-      fzf_lua.live_grep { cwd = tostring(client.dir) }
+      fzf_lua.live_grep { cwd = tostring(client.dir), exec_empty_query = true }
     end
     return
   end

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -181,6 +181,17 @@ command.search = function(client, data)
     return
   end
 
+  local has_fzf_lua, fzf_lua = pcall(require, "fzf-lua")
+
+  if has_fzf_lua then
+    if data.args:len() > 0 then
+      fzf_lua.grep { cwd = tostring(client.dir), search = data.args }
+    else
+      fzf_lua.live_grep { cwd = tostring(client.dir) }
+    end
+    return
+  end
+
   -- Fall back to trying with fzf.vim
   local has_fzf, _ = pcall(function()
     local grep_cmd =
@@ -195,7 +206,7 @@ command.search = function(client, data)
   end)
 
   if not has_fzf then
-    echo.err "Either telescope.nvim or fzf.vim is required for :ObsidianSearch command"
+    echo.err "Either telescope.nvim, fzf-lua or fzf.vim is required for :ObsidianSearch command"
   end
 end
 


### PR DESCRIPTION
Currently the only fuzzy finders implemented are telescope.nvim and fzf.vim. 
I use [fzf-lua](https://github.com/ibhagwan/fzf-lua), which is a lua based fzf plugin, that work like telescope but uses fzf in the background for better performance and, in my opinion, better fuzzy algorithm.