### PR TITLE
Fix navigating to notes in the vault's root directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made more robust to unexpected types in frontmatter.
 - Fixed edge case where frontmatter consisting of exactly one empty field would raise an exception.
 - Fixed `:ObsidianFollowLink` not creating a new note when following a dangling link; matches behavior in the official Obsidian app.
+- Fixed `:ObsidianFollowLink` not considering the vault's root directory.
 
 ## [v1.6.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.6.1) - 2022-10-17
 


### PR DESCRIPTION
I came across this paper cut today. Turns out, Plenary doesn't consider the actual directory it's scanning, only its children. The net effect is that you'd never come across this bug if you only use notes within a subdirectory. But I started using top-level notes today, so I came across this bug.

The official Obsidian app does match this behavior.