### PR TITLE
Fix:  `cmp` stopped working when the `cmp_obsidian_new` was executed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug where creating a new note with `nvim-cmp` completion
+  would cause `nvim-cmp` to stop working.
+
 ## [v1.7.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.7.0) - 2023-02-02
 
 ### Added

--- a/lua/cmp_obsidian_new.lua
+++ b/lua/cmp_obsidian_new.lua
@@ -56,7 +56,7 @@ source.execute = function(_, item, callback)
   local data = item.data
   local client = obsidian.new(data.opts)
   client:new_note(data.title, data.id, vim.fn.expand "%:p:h")
-  return callback
+  return callback { }
 end
 
 ---Get opts.

--- a/lua/cmp_obsidian_new.lua
+++ b/lua/cmp_obsidian_new.lua
@@ -56,7 +56,7 @@ source.execute = function(_, item, callback)
   local data = item.data
   local client = obsidian.new(data.opts)
   client:new_note(data.title, data.id, vim.fn.expand "%:p:h")
-  return callback { }
+  return callback {}
 end
 
 ---Get opts.


### PR DESCRIPTION
Hi! Thank you so much for your plugin. It's great, I love it! Even the original app doesn't give me that much flexibility in the setup.

I discovered a little bug and kind of fixed it. A short demonstration of the bug and bugfix:

https://user-images.githubusercontent.com/45965330/217141439-242e8b11-f96a-4334-bf27-235fc658ed1e.mp4

As I understand it. The callback function is used to communicate the result of the execute function back to the client that called it. If you don't pass anything to the callback function, it means that the function has ended without providing any information about the outcome of the operation. This may result in errors or unintended behavior.

```
$ nvim --version
NVIM v0.8.3
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by builduser
```
```
$ nvim --headless -c 'lua print(require("obsidian").VERSION)' -c q
1.7.0
```