### PR TITLE
Add `:ObsidianRename` command

### DIFF
--- a/test/obsidian/util_spec.lua
+++ b/test/obsidian/util_spec.lua
@@ -36,6 +36,14 @@ describe("obsidian.util", function()
       assert.equals(indices[i][2], expected_indices[i][2])
     end
   end)
+  it("should relink refs to a new link", function()
+    local old_id = "foo"
+    local new_id = "bar"
+    local line = "- [[foo|Foo]] and [[foo]] and [Foo](foo)"
+    local new_line, replaced = util.relink_refs(line, old_id, new_id)
+    assert.equals(replaced, true)
+    assert.equals(new_line, "- [[bar|Foo]] and [[bar]] and [Foo](bar)")
+  end)
   it("should convert a list of params into a string", function()
     local as_string = util.table_params_to_str { "find", "/home/user/obsidian", "-name", "*.md" }
     assert.equals(as_string, "find /home/user/obsidian -name *.md")


### PR DESCRIPTION
The idea is to be able to rename notes as easily as you can from the Obsidian app. The challenge here is that we need to update all backlinks to the old note to use the new file name/ID. To avoid issues of modifying files that might currently be loaded into a buffer, we have to do this in two steps:

- [x] Update all backlinks to the note that are in open buffers of other notes.
- [ ] Update all backlinks to the note in all other notes in the vault that are not currently loaded in a buffer. This will require external dependencies like `find` and `sed`, or if we want to stick with tools from the Rust ecosystem: `fd` and `sd`. Personally I'd prefer the latter since we wouldn't have to account for differences between the Mac vs GNU vs Windows(?) versions of these tools. The downside of course is that it adds more things people need to install.

Other requirements:

- [x] We should be able to update markdown-style links in addition to wikilinks.
- [x] When you select this command, the arguments should auto-populate with the current name of the note.
    ⚠️ NOTE: this works now, but the caveat is you have to TAB after selecting the command to trigger the autocomplete. I'm not sure if there's a way to avoid that.