### PR TITLE
Added support for templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+### Added
+
+- Added `:ObsidianTemplate` to insert a template, configurable using a `templates` table passed to `setup()`.
+
 ## [v1.8.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.8.0) - 2023-02-16
 
 ### Changed
 
 - [`lua-yaml`](https://github.com/exosite/lua-yaml) no-longer bundled as a git submodule. Code from that project has been copied and modified into it's own Lua submodule of `obsidian`.
 - (BREAKING) 'nvim-lua/plenary.nvim' is no-longer bundled, so must be explicitly installed (e.g. Plug 'nvim-lua/plenary.nvim' in your `init.nvim`).
-
-### Added
-
-- Added `:ObsidianTemplate` to insert a template, configurable using a `templates` table passed to `setup()`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`lua-yaml`](https://github.com/exosite/lua-yaml) no-longer bundled as a git submodule. Code from that project has been copied and modified into it's own Lua submodule of `obsidian`.
 - (BREAKING) 'nvim-lua/plenary.nvim' is no-longer bundled, so must be explicitly installed (e.g. Plug 'nvim-lua/plenary.nvim' in your `init.nvim`).
 
+### Added
+
+- Added `:ObsidianTemplate` to insert a template, configurable using a `templates` table passed to `setup()`.
+
 ### Fixed
 
 - Fixed a bug where creating a new note with `nvim-cmp` completion

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Built for people who love the concept of Obsidian -- a simple, markdown-based no
 - `:ObsidianLinkNew` to create a new note and link it to an in-line visual selection of text.
   This command has one optional argument: the title of the new note. If not given, the selected text will be used as the title.
 - `:ObsidianFollowLink` to follow a note reference under the cursor.
+- `:ObsidianTemplates` to insert a template from the templates folder, selecting from a list using [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).
 
 ## Setup
 
@@ -164,6 +165,21 @@ require("obsidian").setup({
   notes_subdir = "notes",
   daily_notes = {
     folder = "notes/dailies",
+  }
+})
+```
+
+#### Templates support
+
+To insert a template, run the command `:ObsidianTemplates`. This will open [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) and allow you to select a template from the templates folder. Select a template and hit `<CR>` to insert. Substitution of `{{date}}`, `{{time}}`, and `{{title}}` is supported. 
+
+```lua
+require("obsidian").setup({
+  dir = "~/my-vault",
+  templates = {
+      subdir = "my-templates-folder",
+      date_format = "%Y-%m-%d-%a",
+      time_format = "%H:%M"
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ require("obsidian").setup({
   }
 })
 ```
+
 and the file `~/my-vault/my-templates-folder/note template.md`:
 
 ```markdown
@@ -195,8 +196,10 @@ Date created: {{date}}
 creating the note `Configuring Neovim.md` and executing `:ObsidianTemplate` will insert
 ```markdown
 # Configuring Neovim
+
 Date created: 2023-03-01-Wed
 ```
+
 above the cursor position.
 
 #### Using nvim-treesitter

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Built for people who love the concept of Obsidian -- a simple, markdown-based no
 - `:ObsidianLinkNew` to create a new note and link it to an in-line visual selection of text.
   This command has one optional argument: the title of the new note. If not given, the selected text will be used as the title.
 - `:ObsidianFollowLink` to follow a note reference under the cursor.
-- `:ObsidianTemplates` to insert a template from the templates folder, selecting from a list using [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).
+- `:ObsidianTemplate` to insert a template from the templates folder, selecting from a list using [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).
 
 ## Setup
 
@@ -171,7 +171,9 @@ require("obsidian").setup({
 
 #### Templates support
 
-To insert a template, run the command `:ObsidianTemplates`. This will open [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) and allow you to select a template from the templates folder. Select a template and hit `<CR>` to insert. Substitution of `{{date}}`, `{{time}}`, and `{{title}}` is supported. 
+To insert a template, run the command `:ObsidianTemplate`. This will open [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) and allow you to select a template from the templates folder. Select a template and hit `<CR>` to insert. Substitution of `{{date}}`, `{{time}}`, and `{{title}}` is supported. 
+
+For example, with the following configuration
 
 ```lua
 require("obsidian").setup({
@@ -183,6 +185,27 @@ require("obsidian").setup({
   }
 })
 ```
+and the file `~/my-vault/my-templates-folder/note template.md`:
+
+```markdown
+---
+aliases = []
+---
+
+# {{title}}
+Date created: {{date}}
+```
+
+creating the note `Configuring Neovim.md` and executing `:ObsidianTemplate` will insert
+```markdown
+---
+aliases = []
+---
+
+# Configuring Neovim
+Date created: 2023-03-01-Wed
+```
+above the cursor position.
 
 #### Using nvim-treesitter
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -236,7 +236,7 @@ command.insert_template = function(client, data)
   -- Telescope hijacks the current window
   local buf = vim.api.nvim_win_get_buf(0)
   local win = vim.api.nvim_get_current_win()
-  local row, _ = unpack(vim.api.nvim_win_get_cursor(win))
+  local row, col = unpack(vim.api.nvim_win_get_cursor(win))
 
   local apply_template = function(name)
     local template_path = Path:new(templates_dir / name)
@@ -259,9 +259,12 @@ command.insert_template = function(client, data)
         table.insert(insert_lines, line)
       end
       template_file:close()
+      table.insert(insert_lines, "")
     end
 
-    vim.api.nvim_buf_set_lines(buf, row - 1, row - 1, false, insert_lines)
+    vim.api.nvim_buf_set_text(buf, row - 1, col, row - 1, col, insert_lines)
+    local new_row, _ = unpack(vim.api.nvim_win_get_cursor(win))
+    vim.api.nvim_win_set_cursor(0, { new_row, 0 })
   end
 
   -- try with telescope.nvim
@@ -273,8 +276,8 @@ command.insert_template = function(client, data)
         attach_mappings = function(_, map)
           map({ "i", "n" }, "<CR>", function(prompt_bufnr)
             local template = require("telescope.actions.state").get_selected_entry()
-            apply_template(template[1])
             require("telescope.actions").close(prompt_bufnr)
+            apply_template(template[1])
           end)
           return true
         end,

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -201,7 +201,7 @@ command.search = function(client, data)
   -- Fall back to trying with fzf.vim
   local has_fzf, _ = pcall(function()
     local grep_cmd =
-    vim.tbl_flatten { base_cmd, { "--color=always", "--", vim.fn.shellescape(data.args), tostring(client.dir) } }
+      vim.tbl_flatten { base_cmd, { "--color=always", "--", vim.fn.shellescape(data.args), tostring(client.dir) } }
 
     vim.api.nvim_call_function("fzf#vim#grep", {
       table.concat(grep_cmd, " "),
@@ -295,34 +295,32 @@ command.insert_template = function(client, data)
       cmd = cmd,
       cwd = tostring(templates_dir),
       file_icons = false,
-      actions = { ["default"] =
-      function(entry)
-        -- for some reason fzf-lua passes the filename with 6 characters
-        -- at the start that appear on screen as 2 whitespace characters
-        -- so we need to start on the 7th character
-        local template = entry[1]:sub(7)
-        apply_template(template)
-      end
-      }
+      actions = {
+        ["default"] = function(entry)
+          -- for some reason fzf-lua passes the filename with 6 characters
+          -- at the start that appear on screen as 2 whitespace characters
+          -- so we need to start on the 7th character
+          local template = entry[1]:sub(7)
+          apply_template(template)
+        end,
+      },
     }
     return
   end
 
-
   -- try with fzf
   local has_fzf, _ = pcall(function()
-    vim.api.nvim_create_user_command("ApplyTemplate",
-      function(path)
-        -- remove escaped whitespace and extract the file name
-        local file_path = string.gsub(path.args, "\\ ", " ")
-        local template = vim.fs.basename(file_path)
-        apply_template(template)
-        vim.api.nvim_del_user_command("ApplyTemplate")
-      end, { nargs = 1, bang = true })
+    vim.api.nvim_create_user_command("ApplyTemplate", function(path)
+      -- remove escaped whitespace and extract the file name
+      local file_path = string.gsub(path.args, "\\ ", " ")
+      local template = vim.fs.basename(file_path)
+      apply_template(template)
+      vim.api.nvim_del_user_command "ApplyTemplate"
+    end, { nargs = 1, bang = true })
 
     local base_cmd = vim.tbl_flatten { util.FIND_CMD, { tostring(templates_dir), "-name", "'*.md'" } }
     base_cmd = util.table_params_to_str(base_cmd)
-    local fzf_options = { source = base_cmd, sink = 'ApplyTemplate' }
+    local fzf_options = { source = base_cmd, sink = "ApplyTemplate" }
     vim.api.nvim_call_function("fzf#run", {
       vim.api.nvim_call_function("fzf#wrap", { fzf_options }),
     })
@@ -332,7 +330,6 @@ command.insert_template = function(client, data)
     echo.err "Either telescope.nvim or fzf.vim is required for :ObsidianTemplate command"
   end
 end
-
 
 ---Quick switch to an obsidian note
 ---
@@ -398,12 +395,12 @@ command.link_new = function(client, data)
   local note = client:new_note(title, nil, vim.fn.expand "%:p:h")
 
   line = string.sub(line, 1, cscol - 1)
-      .. "[["
-      .. note.id
-      .. "|"
-      .. string.sub(line, cscol, cecol)
-      .. "]]"
-      .. string.sub(line, cecol + 1)
+    .. "[["
+    .. note.id
+    .. "|"
+    .. string.sub(line, cscol, cecol)
+    .. "]]"
+    .. string.sub(line, cecol + 1)
   vim.api.nvim_buf_set_lines(0, csrow - 1, csrow, false, { line })
 end
 
@@ -438,12 +435,12 @@ command.link = function(client, data)
   end
 
   line = string.sub(line, 1, cscol - 1)
-      .. "[["
-      .. note.id
-      .. "|"
-      .. string.sub(line, cscol, cecol)
-      .. "]]"
-      .. string.sub(line, cecol + 1)
+    .. "[["
+    .. note.id
+    .. "|"
+    .. string.sub(line, cscol, cecol)
+    .. "]]"
+    .. string.sub(line, cecol + 1)
   vim.api.nvim_buf_set_lines(0, csrow - 1, csrow, false, { line })
 end
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -232,7 +232,7 @@ command.insert_template = function(client, data)
     return
   end
 
-  local has_telescope, telescope = pcall(require, "telescope.builtin")
+  local has_telescope, _ = pcall(require, "telescope.builtin")
   if not has_telescope then
     echo.err "telescope.nvim is required to use the ObsidianTemplate command"
     return
@@ -242,7 +242,7 @@ command.insert_template = function(client, data)
   -- Telescope hijacks the current window
   local buf = vim.api.nvim_win_get_buf(0)
   local win = vim.api.nvim_get_current_win()
-  local row, col = unpack(vim.api.nvim_win_get_cursor(win))
+  local row, _ = unpack(vim.api.nvim_win_get_cursor(win))
 
   local apply_template = function(name)
     local template_path = Path:new(templates_dir / name)
@@ -272,11 +272,10 @@ command.insert_template = function(client, data)
       cwd = tostring(templates_dir),
       attach_mappings = function(_, map)
         map({ "i", "n" }, "<CR>", function(prompt_bufnr)
-          template = require("telescope.actions.state").get_selected_entry()
+          local template = require("telescope.actions.state").get_selected_entry()
           apply_template(template[1])
           require("telescope.actions").close(prompt_bufnr)
         end)
-
         return true
       end,
     }

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -251,7 +251,8 @@ command.insert_template = function(client, data)
     local date = tostring(os.date(date_format))
     local time = tostring(os.date(time_format))
     local fp = vim.api.nvim_buf_get_name(buf)
-    local _, _, title = string.find(vim.fs.normalize(fp), ".*/(.*)%.md")
+    local _, _, title = string.find(vim.fs.normalize(fp), ".*/(.-)%.md")
+    title = title or ""
 
     local insert_lines = {}
     local template_file = io.open(tostring(template_path), "r")

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -233,59 +233,59 @@ command.insert_template = function(client, data)
   end
 
   local has_telescope, telescope = pcall(require, "telescope.builtin")
-  if has_telescope then
-    -- We need to get these upfront otherwise
-    -- Telescope hijacks the current window
-    local buf = vim.api.nvim_win_get_buf(0)
-    local win = vim.api.nvim_get_current_win()
-    local row, col = unpack(vim.api.nvim_win_get_cursor(win))
-
-    local apply_template = function(name)
-      local template_path = Path:new(templates_dir / name)
-      local date_format = client.opts.templates.date_format or "%Y-%m-%d"
-      local time_format = client.opts.templates.time_format or "%H:%M"
-      local date = tostring(os.date(date_format))
-      local time = tostring(os.date(time_format))
-      local fp = vim.api.nvim_buf_get_name(buf)
-      local _, _, title = string.find(vim.fs.normalize(fp), ".*/(.*)%.md")
-
-      local insert_lines = {}
-      local template_file = io.open(tostring(template_path), "r")
-      local lines = template_file:lines()
-      for line in lines do
-        line = string.gsub(line, "{{date}}", date)
-        line = string.gsub(line, "{{time}}", time)
-        line = string.gsub(line, "{{title}}", title)
-        table.insert(insert_lines, line)
-      end
-      template_file:close()
-
-      vim.api.nvim_buf_set_lines(buf, row - 1, row - 1, false, insert_lines)
-    end
-
-    local choose_template = function()
-      local opts = {
-        cwd = tostring(templates_dir),
-        attach_mappings = function(_, map)
-          map({ "i", "n" }, "<CR>", function(prompt_bufnr)
-            template = require("telescope.actions.state").get_selected_entry()
-            apply_template(template[1])
-            require("telescope.actions").close(prompt_bufnr)
-          end)
-
-          return true
-        end,
-      }
-      require("telescope.builtin").find_files(opts)
-    end
-    choose_template()
+  if not has_telescope then
+    echo.err "telescope.nvim is required to use the ObsidianTemplate command"
     return
   end
 
-  if not has_telescope then
-    echo.err "telescope.nvim is required to use the ObsidianTemplate command"
+  -- We need to get these upfront otherwise
+  -- Telescope hijacks the current window
+  local buf = vim.api.nvim_win_get_buf(0)
+  local win = vim.api.nvim_get_current_win()
+  local row, col = unpack(vim.api.nvim_win_get_cursor(win))
+
+  local apply_template = function(name)
+    local template_path = Path:new(templates_dir / name)
+    local date_format = client.opts.templates.date_format or "%Y-%m-%d"
+    local time_format = client.opts.templates.time_format or "%H:%M"
+    local date = tostring(os.date(date_format))
+    local time = tostring(os.date(time_format))
+    local fp = vim.api.nvim_buf_get_name(buf)
+    local _, _, title = string.find(vim.fs.normalize(fp), ".*/(.*)%.md")
+
+    local insert_lines = {}
+    local template_file = io.open(tostring(template_path), "r")
+    local lines = template_file:lines()
+    for line in lines do
+      line = string.gsub(line, "{{date}}", date)
+      line = string.gsub(line, "{{time}}", time)
+      line = string.gsub(line, "{{title}}", title)
+      table.insert(insert_lines, line)
+    end
+    template_file:close()
+
+    vim.api.nvim_buf_set_lines(buf, row - 1, row - 1, false, insert_lines)
   end
+
+  local choose_template = function()
+    local opts = {
+      cwd = tostring(templates_dir),
+      attach_mappings = function(_, map)
+        map({ "i", "n" }, "<CR>", function(prompt_bufnr)
+          template = require("telescope.actions.state").get_selected_entry()
+          apply_template(template[1])
+          require("telescope.actions").close(prompt_bufnr)
+        end)
+
+        return true
+      end,
+    }
+    require("telescope.builtin").find_files(opts)
+  end
+  choose_template()
+  return
 end
+
 
 ---Quick switch to an obsidian note
 ---

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -5,7 +5,10 @@ local config = {}
 ---@class obsidian.config.ClientOpts
 ---@field dir string
 ---@field notes_subdir string|?
----@field templates_subdir string|?
+---@field templates table|?
+---@field templates.subdir string
+---@field templates.date_format string
+---@field templates.time_format string
 ---@field note_id_func function|?
 ---@field note_frontmatter_func function|?
 ---@field disable_frontmatter boolean|?
@@ -20,7 +23,7 @@ config.ClientOpts.default = function()
   return {
     dir = vim.fs.normalize "./",
     notes_subdir = nil,
-    templates_subdir = nil,
+    templates = nil,
     note_id_func = nil,
     note_frontmatter_func = nil,
     disable_frontmatter = false,

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -5,6 +5,7 @@ local config = {}
 ---@class obsidian.config.ClientOpts
 ---@field dir string
 ---@field notes_subdir string|?
+---@field templates_subdir string|?
 ---@field note_id_func function|?
 ---@field note_frontmatter_func function|?
 ---@field disable_frontmatter boolean|?
@@ -19,6 +20,7 @@ config.ClientOpts.default = function()
   return {
     dir = vim.fs.normalize "./",
     notes_subdir = nil,
+    templates_subdir = nil,
     note_id_func = nil,
     note_frontmatter_func = nil,
     disable_frontmatter = false,


### PR DESCRIPTION
I have added a new command `:ObsidianTemplate` that allows inserting of a template from the templates folder. The template is selected using telescope and supports the Obsidian features of substituting `{{date}}`, `{{time}}` and `{{title}}`. The templates folder and date/time formats are configurable via a `templates` table passed to `setup()`.

Unsupported so far is the ability to substitute "one-off" formats for date and time e.g. `{{date:YYYY-MM-DD}}` (in Obsidian's syntax). It would also be nice to read the `templates.json` file directly from `.obsidian` to get the configuration -- I've made some moves toward this but it's not not done yet.