### PR TITLE
Fix `nvim-cmp` completion for notes without aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Gracefully handle invalid aliases / tags in frontmatter (i.e. values that aren't strings). We'll warn about them and ignore the invalid values.
+- Fixed `nvim-cmp` completion for notes that have no `aliases` specified.
 
 ## [v1.8.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.8.0) - 2023-02-16
 

--- a/lua/cmp_obsidian.lua
+++ b/lua/cmp_obsidian.lua
@@ -21,7 +21,8 @@ source.complete = function(self, request, callback)
   if can_complete and search ~= nil and #search >= opts.completion.min_chars then
     local items = {}
     for note in client:search(search, "--ignore-case") do
-      for _, alias in pairs(note.aliases) do
+      local aliases = util.unique { note.id, note:display_name(), unpack(note.aliases) }
+      for _, alias in pairs(aliases) do
         local options = {}
 
         local alias_case_matched = util.match_case(search, alias)

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -17,6 +17,20 @@ util.contains = function(table, val)
   return false
 end
 
+---Return a new table (list) with only the unique values of the original.
+---
+---@param table table
+---@return any[]
+util.unique = function(table)
+  local out = {}
+  for _, val in pairs(table) do
+    if not util.contains(out, val) then
+      out[#out + 1] = val
+    end
+  end
+  return out
+end
+
 ---Find all markdown files in a directory.
 ---
 ---@param dir string|Path


### PR DESCRIPTION
I believe this should fix #102
