### PR TITLE
Fix for `ObsidianOpen` not working with links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `nvim-cmp` completion for notes that have no `aliases` specified.
 - `nvim-cmp` completion will search based on file names now too, not just contents.
 - Fixed bug when `nvim-cmp` is not installed.
+- Workaround error which prevented users from using `ObsidianOpen` when vault path was configured behind a link
 
 ## [v1.8.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.8.0) - 2023-02-16
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Built for people who love the concept of Obsidian -- a simple, markdown-based no
 - `:ObsidianFollowLink` to follow a note reference under the cursor.
 - `:ObsidianTemplate` to insert a template from the templates folder, selecting from a list using [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) or one of the `fzf` alternatives.
 
+### Demo
+
+https://user-images.githubusercontent.com/75107188/227359291-5c4e7bb8-a217-4fbd-aa5d-fd64a57f9783.mov
+
 ## Setup
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -277,3 +277,15 @@ require("obsidian").setup({
   use_advanced_uri = true
 })
 ```
+
+## Known Issues 
+
+### Configuring vault directory behind a link
+
+If you are having issues with commands like `ObsidianOpen`, ensure that your vault is configured to use an absolute path rather than a link. If you must use a link in your configuration, make sure that the name of the vault is present in the file path of the link. For example:
+
+```
+Vault: ~/path/to/vault/parent/obsidian/
+Link: ~/obsidian OR ~/parent
+```
+

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Built for people who love the concept of Obsidian -- a simple, markdown-based no
 
 ### Demo
 
-https://user-images.githubusercontent.com/75107188/227359291-5c4e7bb8-a217-4fbd-aa5d-fd64a57f9783.mov
+https://user-images.githubusercontent.com/75107188/227362168-29ff9d4d-5b62-4aff-9442-21cd8c072d29.mp4
 
 ## Setup
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -101,11 +101,17 @@ command.open = function(client, data)
     end
   else
     local bufname = vim.api.nvim_buf_get_name(0)
+    local vault_name_escaped = vault_name:gsub("%W", "%%%0") .. "%/"
     if vim.loop.os_uname().sysname == "Windows_NT" then
       bufname = bufname:gsub("/", "\\")
+      vault_name_escaped = vault_name_escaped:gsub("/", [[\%\]])
     end
-    path = Path:new(bufname):make_relative(vault)
+
+    local _, j = bufname:find(vault_name_escaped)
+    path = bufname:sub(j)
+    -- path = Path:new(bufname):make_relative(vault) -- doesn't handle links
   end
+
 
   local encoded_vault = util.urlencode(vault_name)
   local encoded_path = util.urlencode(tostring(path))

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -114,7 +114,6 @@ command.open = function(client, data)
     end
   end
 
-
   local encoded_vault = util.urlencode(vault_name)
   local encoded_path = util.urlencode(tostring(path))
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -107,9 +107,11 @@ command.open = function(client, data)
       vault_name_escaped = vault_name_escaped:gsub("/", [[\%\]])
     end
 
-    local _, j = bufname:find(vault_name_escaped)
-    path = bufname:sub(j)
-    -- path = Path:new(bufname):make_relative(vault) -- doesn't handle links
+    path = Path:new(bufname):make_relative(vault)
+    local _, j = path:find(vault_name_escaped)
+    if j ~= nil then
+      path = bufname:sub(j)
+    end
   end
 
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -107,7 +107,18 @@ command.open = function(client, data)
       vault_name_escaped = vault_name_escaped:gsub("/", [[\%\]])
     end
 
+    -- make_relative fails to work when vault path is configured to look behind a link
+    -- make_relative returns an unaltered path if it cannot make the path relative
     path = Path:new(bufname):make_relative(vault)
+
+    -- if the vault name appears in the output of make_relative
+    --          i.e. make_relative has failed
+    -- then remove everything up to and including the vault path
+    -- Example:
+    -- Config path: ~/Dropbox/Documents/0-obsidian-notes/
+    -- File path: /Users/username/Library/CloudStorage/Dropbox/Documents/0-obsidian-notes/Notes/note.md
+    --                                                                   ^
+    -- Proper relative path: Notes/note.md
     local _, j = path:find(vault_name_escaped)
     if j ~= nil then
       path = bufname:sub(j)


### PR DESCRIPTION
Potential fix for #107 

### Summary 

This change modifies the `ObsidianOpen` command to additionally check if Plenary's `make_relative` method fails by attempting to find the vault root directory in the path after the call to `make_relative`. If the vault root directory is found, the new implementation simply substitutes out everything up to and including the root directory in an attempt to make the path work.

### Limitations

- This method will not work if the link which the vault is behind is directly to the vault *and* the name of the link does not match the name of the vault. In this case, both `make_relative` and my proposed fix will fail. To fix this would require actually detecting if the vault is behind a link and following it in order to initialize the vault path as its absolute version from the get go. The only way I could find to accomplish this was to use an external library for Lua, which I figured might not be ideal to require as a dependency for what is really a bit of a niche bug. 
- This will also fail if the user happens to keep their note in a subfolder of their vault which shares the same name as the vault itself. This seemed like a more unlikely scenario than someone wanting their vault directory to be behind a link, which would justify the change.
- I believe I have accounted for Windows paths as well, though I imagine that links will look and function differently in Windows. This change may not work for Windows users as a result. That said, it shouldn't break any existing instances that were already working. 