### PR TITLE
feat: add option `open_app_foreground`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `open_app_foreground` option to open Obsidian.app in foreground on macOS.
 - Added `:ObsidianTemplate` to insert a template, configurable using a `templates` table passed to `setup()`.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -278,6 +278,15 @@ require("obsidian").setup({
 })
 ```
 
+### Open Obsidian.app in foreground (macOS)
+
+By default `ObsidianOpen` opens Obsidian.app in background on macOS. This can be
+changed via `open_app_foreground` option:
+
+```lua
+require("obsidian").setup({ open_app_foreground = true })
+```
+
 ## Known Issues 
 
 ### Configuring vault directory behind a link

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -144,7 +144,11 @@ command.open = function(client, data)
     args = { uri }
   elseif sysname == "Darwin" then
     cmd = "open"
-    args = { "-a", "/Applications/Obsidian.app", "--background", uri }
+    if client.opts.open_app_foreground then
+      args = { "-a", "/Applications/Obsidian.app", uri }
+    else
+      args = { "-a", "/Applications/Obsidian.app", "--background", uri }
+    end
   elseif sysname == "Windows_NT" then
     cmd = "powershell"
     args = { "Start-Process '" .. uri .. "'" }

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -15,6 +15,7 @@ local config = {}
 ---@field completion obsidian.config.CompletionOpts
 ---@field daily_notes obsidian.config.DailyNotesOpts
 ---@field use_advanced_uri boolean|?
+---@field open_app_foreground boolean|?
 config.ClientOpts = {}
 
 ---Get defaults.
@@ -30,6 +31,7 @@ config.ClientOpts.default = function()
     completion = config.CompletionOpts.default(),
     daily_notes = config.DailyNotesOpts.default(),
     use_advanced_uri = nil,
+    open_app_foreground = false,
   }
 end
 


### PR DESCRIPTION
By default Obsidian.app is opened in background on macOS. `open_app_foreground` option enables to open app in foreground.

Close #109 