### PR TITLE
feat: add support to follow links in markdown format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `open_app_foreground` option to open Obsidian.app in foreground on macOS.
 - Added `:ObsidianTemplate` to insert a template, configurable using a `templates` table passed to `setup()`.
+- Added support for following links in markdown format
 
 ### Fixed
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -523,7 +523,15 @@ command.follow = function(client, _)
     return
   end
 
-  local note_name = current_line:sub(open + 2, close - 1)
+  local note_name = current_line:sub(open, close)
+  if note_name:match "^%[.-%]%(.*%)$" then
+    -- transform markdown link to wiki link
+    note_name = note_name:gsub("^%[(.-)%]%((.*)%)$", "%2|%1")
+  else
+    -- wiki link
+    note_name = note_name:sub(3, #note_name - 2)
+  end
+
   local note_file_name = note_name
 
   if note_file_name:match "|[^%]]*" then

--- a/test/obsidian/util_spec.lua
+++ b/test/obsidian/util_spec.lua
@@ -50,4 +50,26 @@ describe("obsidian.util", function()
     assert.equals(#matches, 1)
     assert.equals(tostring(matches[1]), "./test_fixtures/notes/foo.md")
   end)
+  it("should correctly find if coursor is on markdown/wiki link", function()
+    --           0    5    10   15   20   25   30   35   40    45  50   55
+    --           |    |    |    |    |    |    |    |    |    |    |    |
+    local text = "The [other](link/file.md) plus [[yet|another/file.md]] there"
+    local tests = {
+      { cur_col = 4, open = nil, close = nil },
+      { cur_col = 5, open = 5, close = 25 },
+      { cur_col = 7, open = 5, close = 25 },
+      { cur_col = 25, open = 5, close = 25 },
+      { cur_col = 26, open = nil, close = nil },
+      { cur_col = 31, open = nil, close = nil },
+      { cur_col = 32, open = 32, close = 54 },
+      { cur_col = 40, open = 32, close = 54 },
+      { cur_col = 54, open = 32, close = 54 },
+      { cur_col = 55, open = nil, close = nil },
+    }
+    for _, test in ipairs(tests) do
+      local open, close = util.cursor_on_markdown_link(text, test.cur_col)
+      assert.equals(test.open, open, "cursor at: " .. test.cur_col)
+      assert.equals(test.close, close, "close")
+    end
+  end)
 end)


### PR DESCRIPTION
Currently this plugin supports links in wiki format like this:
```
[[some/file.md|My file]]
```
but markdown links looks bit different 
```
[My file](some/file.md)
```

This PR will add support for markdown links to `ObsidianFollowLink` command as well as `utils.cursor_on_markdown_link`  function.