### PR TITLE
Respect disable_frontmatter when for daily notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- A bug when `disable_frontmatter` is ignored for `ObsidianToday` and `ObsidianYesterday`.
+
 ## [v1.10.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.10.0) - 2023-05-11
 
 ### Added

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -273,7 +273,7 @@ client.today = function(self)
   -- Create Note object and save if it doesn't already exist.
   local note = obsidian.note.new(id, { alias }, { "daily-notes" }, path)
   if not note:exists() then
-    note:save()
+    note:save(nil, not self.opts.disable_frontmatter)
     echo.info("Created note " .. tostring(note.id) .. " at " .. tostring(note.path))
   end
 
@@ -295,7 +295,7 @@ client.yesterday = function(self)
   -- Create Note object and save if it doesn't already exist.
   local note = obsidian.note.new(id, { alias }, { "daily-notes" }, path)
   if not note:exists() then
-    note:save()
+    note:save(nil, not self.opts.disable_frontmatter)
     echo.info("Created note " .. tostring(note.id) .. " at " .. tostring(note.path))
   end
 

--- a/test/obsidian/client_spec.lua
+++ b/test/obsidian/client_spec.lua
@@ -1,4 +1,5 @@
 local Path = require "plenary.path"
+local Note = require "obsidian.note"
 local obsidian = require "obsidian"
 
 ---Get a client in a temporary directory.
@@ -22,5 +23,23 @@ describe("Client", function()
     local note = client:today()
     assert.is_true(note.path ~= nil)
     assert.is_true(note:exists())
+  end)
+
+  it("should not add frontmatter for today when disabled", function()
+    local client = tmp_client()
+    client.opts.disable_frontmatter = true
+    local new_note = client:today()
+
+    local saved_note = Note.from_file(new_note.path)
+    assert.is_false(saved_note.has_frontmatter)
+  end)
+
+  it("should not add frontmatter for yesterday when disabled", function()
+    local client = tmp_client()
+    client.opts.disable_frontmatter = true
+    local new_note = client:yesterday()
+
+    local saved_note = Note.from_file(new_note.path)
+    assert.is_false(saved_note.has_frontmatter)
   end)
 end)


### PR DESCRIPTION
Do not add frontmatter when disabled while using `:ObsidianToday` and `:ObsidianYesterday`.