### PR TITLE
Fix bug in ObsidianTemplate with telescope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A bug when `disable_frontmatter` is ignored for `ObsidianToday` and `ObsidianYesterday`.
+- A bug with `ObsidianTemplate` when using Telescope
 
 ## [v1.10.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.10.0) - 2023-05-11
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -313,6 +313,7 @@ command.insert_template = function(client, data)
               require("telescope.actions").close(prompt_bufnr)
               apply_template(template[1])
             end)
+            return true
           end,
         }
         require("telescope.builtin").find_files(opts)


### PR DESCRIPTION
When i try to use :ObsidianTemplate i see such an error

Error detected while processing command line:
[Obsidian] ...ocal/share/nvim/lazy/obsidian.nvim/lua/obsidian/util.lua:465: ...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:310: Attach mappings must always ret
urn a value. `true` means use default mappings, `false` means only use attached mappings