### PR TITLE
fix: disable managed frontmatter for templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Disabled managed frontmatter for files in the templates subdirectory.
 - A bug when `disable_frontmatter` is ignored for `ObsidianToday` and `ObsidianYesterday`.
 - A bug with `ObsidianTemplate` when using Telescope
 

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -119,15 +119,17 @@ obsidian.setup = function(opts)
 
       local bufnr = vim.api.nvim_get_current_buf()
       local note = obsidian.note.from_buffer(bufnr, self.dir)
-      if note:should_save_frontmatter() and self.opts.disable_frontmatter ~= true then
-        local frontmatter = nil
-        if self.opts.note_frontmatter_func ~= nil then
-          frontmatter = self.opts.note_frontmatter_func(note)
-        end
-        local lines = note:frontmatter_lines(nil, frontmatter)
-        vim.api.nvim_buf_set_lines(bufnr, 0, note.frontmatter_end_line and note.frontmatter_end_line or 0, false, lines)
-        echo.info "Updated frontmatter"
+      if not note:should_save_frontmatter() or self.opts.disable_frontmatter == true then
+        return
       end
+
+      local frontmatter = nil
+      if self.opts.note_frontmatter_func ~= nil then
+        frontmatter = self.opts.note_frontmatter_func(note)
+      end
+      local lines = note:frontmatter_lines(nil, frontmatter)
+      vim.api.nvim_buf_set_lines(bufnr, 0, note.frontmatter_end_line and note.frontmatter_end_line or 0, false, lines)
+      echo.info "Updated frontmatter"
     end,
   })
 


### PR DESCRIPTION
closes #141

I decided to rebrand this as a fix, because it changes existing behavior.

If you want me to add the configuration option to reenable the current behavior (as described in #141) you need to decide what the default should be and how the two options for enabling the managed frontmatter should interact.