### PR TITLE
Refactor ObsidianTemplate and allow user to choose template via argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Allow user to supply an argument to `ObsidianTemplate` to select a template.
+- Renamed `command.insert_template()` to `command.template()` and split the template insert script into a separate function `util.insert_template()`.
+
 ## [v1.11.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.11.0) - 2023-06-09
 
 ### Added

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -12,6 +12,7 @@ obsidian.util = require "obsidian.util"
 
 ---@class obsidian.Client
 ---@field dir Path
+---@field templates_dir Path|?
 ---@field opts obsidian.config.ClientOpts
 ---@field backlinks_namespace integer
 local client = {}
@@ -61,6 +62,13 @@ obsidian.setup = function(opts)
     local daily_notes_subdir = self.dir / self.opts.daily_notes.folder
     daily_notes_subdir:mkdir { parents = true, exists_ok = true }
     vim.cmd("set path+=" .. vim.fn.fnameescape(tostring(daily_notes_subdir)))
+  end
+
+  if self.opts.templates.subdir ~= nil then
+    self.templates_dir = Path:new(self.dir) / self.opts.templates.subdir
+    if not self.templates_dir:is_dir() then
+      echo.err(string.format("%s is not a valid directory for templates", self.templates_dir))
+    end
   end
 
   -- Register commands.

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -434,6 +434,50 @@ util.working_day_before = function(time)
   end
 end
 
+---
+---
+---@return table - tuple containing {bufnr, winnr, row, col}
+util.get_active_window_cursor_location = function()
+  local buf = vim.api.nvim_win_get_buf(0)
+  local win = vim.api.nvim_get_current_win()
+  local row, col = unpack(vim.api.nvim_win_get_cursor(win))
+  local location = { buf, win, row, col }
+  return location
+end
+
+---Insert a template at the given location.
+---
+---@param name string - name of a template in the configured templates folder
+---@param client obsidian.Client
+---@param location table - a tuple with {bufnr, winnr, row, col}
+util.insert_template = function(name, client, location)
+  local buf, win, row, col = unpack(location)
+  local template_path = Path:new(client.templates_dir) / name
+  local date_format = client.opts.templates.date_format or "%Y-%m-%d"
+  local time_format = client.opts.templates.time_format or "%H:%M"
+  local date = tostring(os.date(date_format))
+  local time = tostring(os.date(time_format))
+  local title = require("obsidian.note").from_buffer(buf, client.dir):display_name()
+
+  local insert_lines = {}
+  local template_file = io.open(tostring(template_path), "r")
+  if template_file then
+    local lines = template_file:lines()
+    for line in lines do
+      line = string.gsub(line, "{{date}}", date)
+      line = string.gsub(line, "{{time}}", time)
+      line = string.gsub(line, "{{title}}", title)
+      table.insert(insert_lines, line)
+    end
+    template_file:close()
+    table.insert(insert_lines, "")
+  end
+
+  vim.api.nvim_buf_set_text(buf, row - 1, col, row - 1, col, insert_lines)
+  local new_cursor_row, _ = unpack(vim.api.nvim_win_get_cursor(win))
+  vim.api.nvim_win_set_cursor(0, { new_cursor_row, 0 })
+end
+
 local IMPLEMENTATION_UNAVAILABLE = { "implementation_unavailable called from outside run_first_supported" }
 
 ---Try implementations one by one in the given order, until finding one that is supported


### PR DESCRIPTION
Refactored ObsidianTemplate, separating template selection using the file picker from the template insertion script.

Also allow user to supply  an argument to `ObsidianTemplate` to select the template without invoking Telescope/fzf, for more powerful custom bindings

The insertion script was moved to `obsidian.util` for now. I considered `obsidian.note` but the script operates on a buffer at a given cursor location rather than a note file as such so I wasn't sure it was a good fit.