### PR TITLE
fix(is_template check): swap out call to viml string match function for builtin lua function.

### DIFF
--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -98,7 +98,7 @@ obsidian.setup = function(opts)
   if self.opts.templates ~= nil then
     local templates_pattern = "^" .. tostring(self.dir / self.opts.templates.subdir / ".*")
     is_template = function(match)
-      return vim.fn.matchstr(match, templates_pattern) ~= ""
+      return string.find(match, templates_pattern) ~= nil
     end
   else
     is_template = function(_)


### PR DESCRIPTION
Hi @epwalsh, 

Thanks for the great plugin, I have just noticed this bug on my system. I'm not sure anyone else has experienced it but I thought I'd propose a fix since it seemed pretty straightforward. (Although I'm no Lua expert) 

The issue is that for a path to a vault that contained tildes (like a path to a folder in iCloud), the `is_template` function throws errors when calling the vim `matchstr` function. Swapping it out for the lua string match function eliminated the error for me. 

example setup that previously caused errors. 
```lua
require("obsidian").setup({
dir="/Users/person/Library/Mobile Documents/iCloud~md~obsidian/Documents/Notes",
    notes_subdir = "fleeting",
    templates = {
      subdir = "Templates",
      date_format = "%Y-%m-%d-%a",
      time_format = "%H:%M"
  },
...
```