### PR TITLE
Fix ObsidianFollowLink with header links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed creating new notes when the title of the note contains a path. Now that path will always be treated as relative to the vault, not the `notes_subdir`.
+- Fixed `ObsidianFollowLink` when the note path contains a header link (e.g. `[[foo#Bar]]`).
 
 ## [v1.11.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.11.0) - 2023-06-09
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -545,12 +545,14 @@ command.follow = function(client, _)
     note_name = note_name:sub(3, #note_name - 2)
   end
 
+  -- Split note file name/path from note name/alias.
   local note_file_name = note_name
   if note_name:match "|[^%]]*" then
     note_file_name = note_file_name:sub(1, note_file_name:find "|" - 1)
     note_name = note_name:sub(note_name:find "|" + 1, note_name:len())
   end
 
+  -- Check if it's a URL.
   if note_file_name:match "^[%a%d]*%:%/%/" then
     if client.opts.follow_url_func ~= nil then
       client.opts.follow_url_func(note_file_name)
@@ -563,10 +565,18 @@ command.follow = function(client, _)
     return
   end
 
+  -- Remove header link from the end if there is one.
+  local header_link = note_file_name:match "#[%a%d-_]+$"
+  if header_link ~= nil then
+    note_file_name = note_file_name:sub(1, -header_link:len() - 1)
+  end
+
+  -- Ensure file name ends with suffix.
   if not note_file_name:match "%.md" then
     note_file_name = note_file_name .. ".md"
   end
 
+  -- Search for matching notes.
   local notes = util.find_note(client.dir, note_file_name)
 
   if #notes < 1 then


### PR DESCRIPTION
Fixes `:ObsidianFollowLink` when the link contains a header reference, e.g. `[[foo#Bar]]`.
Previously this would attempt to create a new note with the filename `foo#Bar.md`.

See https://github.com/epwalsh/obsidian.nvim/issues/50#issuecomment-1636676763
