### PR TITLE
Remove leading | if note_id_func returns '' or nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v1.12.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.12.0) - 2023-07-15
+
 ### Added
 
 - Allow user to supply an argument to `ObsidianTemplate` to select a template.

--- a/README.md
+++ b/README.md
@@ -169,8 +169,7 @@ This is a complete list of all of the options that can be passed to `require("ob
     prepend_note_id = true
   },
 
-  -- Optional, customize how names/IDs for new notes are created. If nil or an empty string
-  -- is returned the id will be ignored.
+  -- Optional, customize how names/IDs for new notes are created.
   note_id_func = function(title)
     -- Create note IDs in a Zettelkasten format with a timestamp and a suffix.
     -- In this case a note with the title 'My new note' will given an ID that looks

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ This is a complete list of all of the options that can be passed to `require("ob
     --  * "notes_subdir" - put new notes in the default notes subdirectory.
     new_notes_location = "current_dir",
 
-    -- Whether to add the output of the node_id_func to new notes in autocompletion
+    -- Whether to add the output of the node_id_func to new notes in autocompletion.
+    -- E.g. "[[Foo" completes to "[[foo|Foo]]" assuming "foo" is the ID of the note.
     prepend_note_id = true
   },
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ This is a complete list of all of the options that can be passed to `require("ob
     -- Where to put new notes created from completion. Valid options are
     --  * "current_dir" - put new notes in same directory as the current buffer.
     --  * "notes_subdir" - put new notes in the default notes subdirectory.
-    new_notes_location = "current_dir"
+    new_notes_location = "current_dir",
+
+    -- Whether to add the output of the node_id_func to new notes in autocompletion
+    prepend_note_id = true
   },
 
   -- Optional, customize how names/IDs for new notes are created. If nil or an empty string

--- a/lua/cmp_obsidian_new.lua
+++ b/lua/cmp_obsidian_new.lua
@@ -24,8 +24,8 @@ source.complete = function(self, request, callback)
     local new_id = client:new_note_id(search)
     local items = {}
     local new_title = search
-    if new_id ~= '' and new_id ~= nil then
-        new_title = new_id .. '|' .. search
+    if new_id ~= "" and new_id ~= nil then
+        new_title = new_id .. "|" .. search
     end
     table.insert(items, {
       sortText = "[[" .. search,

--- a/lua/cmp_obsidian_new.lua
+++ b/lua/cmp_obsidian_new.lua
@@ -25,7 +25,7 @@ source.complete = function(self, request, callback)
     local items = {}
     local new_title = search
     if new_id ~= "" and new_id ~= nil then
-        new_title = new_id .. "|" .. search
+      new_title = new_id .. "|" .. search
     end
     table.insert(items, {
       sortText = "[[" .. search,

--- a/lua/cmp_obsidian_new.lua
+++ b/lua/cmp_obsidian_new.lua
@@ -24,7 +24,7 @@ source.complete = function(self, request, callback)
     local new_id = client:new_note_id(search)
     local items = {}
     local new_title = search
-    if new_id ~= "" and new_id ~= nil then
+    if opts.completion.prepend_note_id then
       new_title = new_id .. "|" .. search
     end
     table.insert(items, {

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -57,6 +57,7 @@ end
 ---@field nvim_cmp boolean
 ---@field min_chars integer
 ---@field new_notes_location "current_dir"|"notes_subdir"
+---@field prepend_note_id boolean
 config.CompletionOpts = {}
 
 ---Get defaults.
@@ -67,6 +68,7 @@ config.CompletionOpts.default = function()
     nvim_cmp = has_nvim_cmp,
     min_chars = 2,
     new_notes_location = "current_dir",
+    prepend_note_id = true,
   }
 end
 

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -5,7 +5,7 @@ local config = require "obsidian.config"
 
 local obsidian = {}
 
-obsidian.VERSION = "1.11.0"
+obsidian.VERSION = "1.12.0"
 obsidian.completion = require "obsidian.completion"
 obsidian.note = require "obsidian.note"
 obsidian.util = require "obsidian.util"


### PR DESCRIPTION
Resolves #159
Adjusts `cmp_obsidian_new` so that if the `note_id_func` function returns an empty string or nil, there is no longer a leading `|`. 
I've confirmed on my end that this works with the following config:
```lua
    note_id_func = function (_)
        return ''
    end
```
![image](https://github.com/epwalsh/obsidian.nvim/assets/10048014/889caff8-03d9-4ad9-9dab-c4423a435969)

I believe I've updated all relevant documentation and changelogs in accordance with the contributing guidelines.