### PR TITLE
Automatically configure 'gf' passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - (internal) Refactored daily note creation.
-- obsidian.nvim will now automatically enable the 'gf' passthrough keybinding within your vault unless the 'gf' keybinding has already been overridden you or another plugin or you set 'keybindings.gf_passthrough = false' in your obsidian.nvim config.
+- obsidian.nvim will now automatically enable the 'gf' passthrough keybinding within your vault unless the 'gf' keybinding has already been overridden you or another plugin or you set 'mappings.gf_passthrough = false' in your obsidian.nvim config.
 
 ## [v1.12.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.12.0) - 2023-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added option `prepend_note_id` to allow disabling id generation for new notes
+- Added option `prepend_note_id` to allow disabling id generation for new notes.
+- Added `mappings` configuration field.
 
 ### Changed
 
 - (internal) Refactored daily note creation.
-- obsidian.nvim will now automatically enable the 'gf' passthrough keybinding within your vault unless the 'gf' keybinding has already been overridden you or another plugin or you set 'mappings.gf_passthrough = false' in your obsidian.nvim config.
+- obsidian.nvim will now automatically enable the 'gf' passthrough keybinding within your vault unless the 'gf' keybinding has already been overridden by you or another plugin or you override the 'mappings' configuration field.
 
 ## [v1.12.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.12.0) - 2023-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - (internal) Refactored daily note creation.
+- obsidian.nvim will now automatically enable the 'gf' passthrough keybinding within your vault unless the 'gf' keybinding has already been overridden you or another plugin or you set 'keybindings.gf_passthrough = false' in your obsidian.nvim config.
 
 ## [v1.12.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.12.0) - 2023-07-15
 

--- a/README.md
+++ b/README.md
@@ -86,19 +86,6 @@ return {
 
     -- see below for full list of options 👇
   },
-  config = function(_, opts)
-    require("obsidian").setup(opts)
-
-    -- Optional, override the 'gf' keymap to utilize obsidian.nvim's search functionality.
-    -- see also: 'follow_url_func' config option below.
-    vim.keymap.set("n", "gf", function()
-      if require("obsidian").util.cursor_on_markdown_link() then
-        return "<cmd>ObsidianFollowLink<CR>"
-      else
-        return "gf"
-      end
-    end, { noremap = false, expr = true })
-  end,
 }
 ```
 
@@ -172,6 +159,12 @@ This is a complete list of all of the options that can be passed to `require("ob
     -- Whether to add the output of the node_id_func to new notes in autocompletion.
     -- E.g. "[[Foo" completes to "[[foo|Foo]]" assuming "foo" is the ID of the note.
     prepend_note_id = true
+  },
+
+  -- Optional, keybindings.
+  keybindings = {
+    -- Overrides the 'gf' keybinding to work on markdown/wiki links within your vault.
+    gf_passthrough = true,
   },
 
   -- Optional, customize how names/IDs for new notes are created.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,17 @@ This is a complete list of all of the options that can be passed to `require("ob
 - obsidian.nvim will set itself up as an nvim-cmp source automatically when you enter a markdown buffer within your vault directory, you do **not** need to specify this plugin as a cmp source manually.
 - If you use `vim-markdown` you'll probably want to disable its frontmatter syntax highlighting (`vim.g.vim_markdown_frontmatter = 1`) which I've found doesn't work very well.
 - The `notes_subdir` and `note_id_func` options are not mutually exclusive. You can use them both. For example, using a combination of both of the above settings, a new note called "My new note" will assigned a path like `notes/1657296016-my-new-note.md`.
+- If you want the `gf` passthrough functionality but you've already overridden the `gf` keybinding, just change your `gf` mapping definition to something like this:
+
+  ```lua
+  vim.keymap.set("n", "gf", function()
+    if require("obsidian").util.cursor_on_markdown_link() then
+      return "<cmd>ObsidianFollowLink<CR>"
+    else
+      return "gf"
+    end
+  end, { noremap = false, expr = true })
+  ```
 
 ### Templates support
 

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ This is a complete list of all of the options that can be passed to `require("ob
     prepend_note_id = true
   },
 
-  -- Optional, keybindings.
-  keybindings = {
-    -- Overrides the 'gf' keybinding to work on markdown/wiki links within your vault.
+  -- Optional, key mappings.
+  mappings = {
+    -- Overrides the 'gf' mapping to work on markdown/wiki links within your vault.
     gf_passthrough = true,
   },
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This is a complete list of all of the options that can be passed to `require("ob
   -- Optional, key mappings.
   mappings = {
     -- Overrides the 'gf' mapping to work on markdown/wiki links within your vault.
-    gf_passthrough = true,
+    ["gf"] = require("obsidian.mapping").gf_passthrough(),
   },
 
   -- Optional, customize how names/IDs for new notes are created.

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -15,7 +15,7 @@ local config = {}
 ---@field note_frontmatter_func function|?
 ---@field disable_frontmatter boolean|?
 ---@field completion obsidian.config.CompletionOpts
----@field keybindings obsidian.config.KeyBindingOpts
+---@field mappings obsidian.config.MappingOpts
 ---@field daily_notes obsidian.config.DailyNotesOpts
 ---@field use_advanced_uri boolean|?
 ---@field open_app_foreground boolean|?
@@ -35,7 +35,7 @@ config.ClientOpts.default = function()
     note_frontmatter_func = nil,
     disable_frontmatter = false,
     completion = config.CompletionOpts.default(),
-    keybindings = config.KeyBindingOpts.default(),
+    mappings = config.MappingOpts.default(),
     daily_notes = config.DailyNotesOpts.default(),
     use_advanced_uri = nil,
     open_app_foreground = false,
@@ -50,7 +50,7 @@ end
 config.ClientOpts.normalize = function(opts)
   opts = vim.tbl_extend("force", config.ClientOpts.default(), opts)
   opts.completion = vim.tbl_extend("force", config.CompletionOpts.default(), opts.completion)
-  opts.keybindings = vim.tbl_extend("force", config.KeyBindingOpts.default(), opts.keybindings)
+  opts.mappings = vim.tbl_extend("force", config.MappingOpts.default(), opts.mappings)
   opts.daily_notes = vim.tbl_extend("force", config.DailyNotesOpts.default(), opts.daily_notes)
   opts.dir = vim.fs.normalize(tostring(opts.dir))
   return opts
@@ -75,13 +75,13 @@ config.CompletionOpts.default = function()
   }
 end
 
----@class obsidian.config.KeyBindingOpts
+---@class obsidian.config.MappingOpts
 ---@field gf_passthrough boolean
-config.KeyBindingOpts = {}
+config.MappingOpts = {}
 
 ---Get defaults.
----@return obsidian.config.KeyBindingOpts
-config.KeyBindingOpts.default = function()
+---@return obsidian.config.MappingOpts
+config.MappingOpts.default = function()
   return {
     gf_passthrough = true,
   }

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -15,6 +15,7 @@ local config = {}
 ---@field note_frontmatter_func function|?
 ---@field disable_frontmatter boolean|?
 ---@field completion obsidian.config.CompletionOpts
+---@field keybindings obsidian.config.KeyBindingOpts
 ---@field daily_notes obsidian.config.DailyNotesOpts
 ---@field use_advanced_uri boolean|?
 ---@field open_app_foreground boolean|?
@@ -34,6 +35,7 @@ config.ClientOpts.default = function()
     note_frontmatter_func = nil,
     disable_frontmatter = false,
     completion = config.CompletionOpts.default(),
+    keybindings = config.KeyBindingOpts.default(),
     daily_notes = config.DailyNotesOpts.default(),
     use_advanced_uri = nil,
     open_app_foreground = false,
@@ -48,6 +50,7 @@ end
 config.ClientOpts.normalize = function(opts)
   opts = vim.tbl_extend("force", config.ClientOpts.default(), opts)
   opts.completion = vim.tbl_extend("force", config.CompletionOpts.default(), opts.completion)
+  opts.keybindings = vim.tbl_extend("force", config.KeyBindingOpts.default(), opts.keybindings)
   opts.daily_notes = vim.tbl_extend("force", config.DailyNotesOpts.default(), opts.daily_notes)
   opts.dir = vim.fs.normalize(tostring(opts.dir))
   return opts
@@ -69,6 +72,18 @@ config.CompletionOpts.default = function()
     min_chars = 2,
     new_notes_location = "current_dir",
     prepend_note_id = true,
+  }
+end
+
+---@class obsidian.config.KeyBindingOpts
+---@field gf_passthrough boolean
+config.KeyBindingOpts = {}
+
+---Get defaults.
+---@return obsidian.config.KeyBindingOpts
+config.KeyBindingOpts.default = function()
+  return {
+    gf_passthrough = true,
   }
 end
 

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -50,7 +50,7 @@ end
 config.ClientOpts.normalize = function(opts)
   opts = vim.tbl_extend("force", config.ClientOpts.default(), opts)
   opts.completion = vim.tbl_extend("force", config.CompletionOpts.default(), opts.completion)
-  opts.mappings = vim.tbl_extend("force", config.MappingOpts.default(), opts.mappings)
+  opts.mappings = opts.mappings and opts.mappings or config.MappingOpts.default()
   opts.daily_notes = vim.tbl_extend("force", config.DailyNotesOpts.default(), opts.daily_notes)
   opts.dir = vim.fs.normalize(tostring(opts.dir))
   return opts
@@ -76,14 +76,13 @@ config.CompletionOpts.default = function()
 end
 
 ---@class obsidian.config.MappingOpts
----@field gf_passthrough boolean
 config.MappingOpts = {}
 
 ---Get defaults.
 ---@return obsidian.config.MappingOpts
 config.MappingOpts.default = function()
   return {
-    gf_passthrough = true,
+    ["gf"] = require("obsidian.mapping").gf_passthrough(),
   }
 end
 

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -9,6 +9,7 @@ obsidian.VERSION = "1.12.0"
 obsidian.completion = require "obsidian.completion"
 obsidian.note = require "obsidian.note"
 obsidian.util = require "obsidian.util"
+obsidian.mapping = require "obsidian.mapping"
 
 ---@class obsidian.Client
 ---@field dir Path
@@ -92,21 +93,21 @@ obsidian.setup = function(opts)
       cmp.setup.buffer { sources = sources }
     end
 
-    -- Keybindings...
-    -- 'gf' passthrough
-    if opts.mappings.gf_passthrough then
-      local gf_set_by = vim.fn.mapcheck("gf", "n")
-      if gf_set_by == "" then
-        -- 'gf' has not been overridden by user or other plugin so we can safely set it.
-        vim.keymap.set("n", "gf", function()
-          if require("obsidian").util.cursor_on_markdown_link() then
-            return "<cmd>ObsidianFollowLink<CR>"
-          else
-            return "gf"
-          end
-        end, { noremap = false, expr = true, buffer = true })
-      elseif not string.find(gf_set_by, "obsidian") then
-        echo.warn("Obsidian cannot override 'gf' keybinding since 'gf' is already set by " .. gf_set_by, opts.log_level)
+    -- Mappings...
+    for mapping_keys, mapping_config in pairs(opts.mappings) do
+      local mapping_set_by = vim.fn.mapcheck(mapping_keys, "n")
+      if mapping_set_by == "" then
+        vim.keymap.set("n", mapping_keys, mapping_config.action, mapping_config.opts)
+      elseif not string.find(mapping_set_by, "obsidian") then
+        echo.warn(
+          "Obsidian cannot override '"
+            .. mapping_keys
+            .. "' keybinding since '"
+            .. mapping_keys
+            .. "' has been set by "
+            .. mapping_set_by,
+          opts.log_level
+        )
       end
     end
   end

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -94,7 +94,7 @@ obsidian.setup = function(opts)
 
     -- Keybindings...
     -- 'gf' passthrough
-    if opts.keybindings.gf_passthrough then
+    if opts.mappings.gf_passthrough then
       local gf_set_by = vim.fn.mapcheck("gf", "n")
       if gf_set_by == "" then
         -- 'gf' has not been overridden by user or other plugin so we can safely set it.

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -91,6 +91,24 @@ obsidian.setup = function(opts)
       end
       cmp.setup.buffer { sources = sources }
     end
+
+    -- Keybindings...
+    -- 'gf' passthrough
+    if opts.keybindings.gf_passthrough then
+      local gf_set_by = vim.fn.mapcheck("gf", "n")
+      if gf_set_by == "" then
+        -- 'gf' has not been overridden by user or other plugin so we can safely set it.
+        vim.keymap.set("n", "gf", function()
+          if require("obsidian").util.cursor_on_markdown_link() then
+            return "<cmd>ObsidianFollowLink<CR>"
+          else
+            return "gf"
+          end
+        end, { noremap = false, expr = true, buffer = true })
+      elseif not string.find(gf_set_by, "obsidian") then
+        echo.warn("Obsidian cannot override 'gf' keybinding since 'gf' is already set by " .. gf_set_by, opts.log_level)
+      end
+    end
   end
 
   --- @type fun(match: string): boolean

--- a/lua/obsidian/mapping.lua
+++ b/lua/obsidian/mapping.lua
@@ -1,0 +1,21 @@
+local mapping = {}
+
+---@class obsidian.mapping.MappingConfig
+---@field action function
+---@field opts table
+
+---@return obsidian.mapping.MappingConfig
+mapping.gf_passthrough = function()
+  local action = function()
+    if require("obsidian").util.cursor_on_markdown_link() then
+      return "<cmd>ObsidianFollowLink<CR>"
+    else
+      return "gf"
+    end
+  end
+
+  local opts = { noremap = false, expr = true, buffer = true }
+  return { action = action, opts = opts }
+end
+
+return mapping

--- a/test/obsidian/note_spec.lua
+++ b/test/obsidian/note_spec.lua
@@ -20,7 +20,7 @@ describe("Note", function()
     local note = Note.from_file "README.md"
     assert.equals(note.id, "README")
     assert.equals(#note.aliases, 1)
-    assert.equals(note.aliases[1], "Obsidian.nvim")
+    assert.equals(note.aliases[1], "obsidian.nvim")
     assert.equals(#note.tags, 0)
     assert.equals(note:fname(), "README.md")
     assert.is_false(note:should_save_frontmatter())


### PR DESCRIPTION
Fixes #157.

- Adds a `mappings` field to the config.
- obsidian.nvim will now automatically configure the 'gf' passthrough unless this keybinding was already set or you override the `mappings` field in your obsidian.nvim config.
