### PR TITLE
add backlinks config opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added option `prepend_note_id` to allow disabling id generation for new notes.
 - Added `mappings` configuration field.
 - Added `open_notes_in` configuration field
+- Added `backlinks` options to the config. The default is
+    ```lua
+    backlinks = {
+      -- The default height of the backlinks pane.
+      height = 10,
+      -- Whether or not to wrap lines.
+      wrap = true,
+    },
+    ```
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ This is a complete list of all of the options that can be passed to `require("ob
     time_format = "%H:%M",
   },
 
+  -- Optional, customize the backlinks interface.
+  backlinks = {
+    -- The default height of the backlinks pane.
+    height = 10,
+    -- Whether or not to wrap lines.
+    wrap = true,
+  },
+
   -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
   -- URL it will be ignored but you can customize this behavior here.
   follow_url_func = function(url)

--- a/lua/obsidian/backlinks.lua
+++ b/lua/obsidian/backlinks.lua
@@ -125,7 +125,7 @@ backlinks.view = function(self)
   -- Clear any existing backlinks buffer.
   wipe_rogue_buffer()
 
-  vim.api.nvim_command "botright 10split ObsidianBacklinks"
+  vim.api.nvim_command("botright " .. tostring(self.client.opts.backlinks.height) .. "split ObsidianBacklinks")
 
   -- Configure buffer.
   vim.cmd "setlocal nonu"
@@ -137,7 +137,7 @@ backlinks.view = function(self)
   vim.api.nvim_buf_set_option(0, "buflisted", false)
   vim.api.nvim_buf_set_var(0, "obsidian_vault_dir", tostring(self.client.dir))
   vim.api.nvim_buf_set_var(0, "obsidian_parent_win", self.winnr)
-  vim.api.nvim_win_set_option(0, "wrap", false)
+  vim.api.nvim_win_set_option(0, "wrap", self.client.opts.backlinks.wrap)
   vim.api.nvim_win_set_option(0, "spell", false)
   vim.api.nvim_win_set_option(0, "list", false)
   vim.api.nvim_win_set_option(0, "signcolumn", "no")

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -14,6 +14,7 @@ local config = {}
 ---@field follow_url_func function|?
 ---@field note_frontmatter_func function|?
 ---@field disable_frontmatter boolean|?
+---@field backlinks obsidian.config.BacklinksOpts
 ---@field completion obsidian.config.CompletionOpts
 ---@field mappings obsidian.config.MappingOpts
 ---@field daily_notes obsidian.config.DailyNotesOpts
@@ -35,6 +36,7 @@ config.ClientOpts.default = function()
     follow_url_func = nil,
     note_frontmatter_func = nil,
     disable_frontmatter = false,
+    backlinks = config.BacklinksOpts.default(),
     completion = config.CompletionOpts.default(),
     mappings = config.MappingOpts.default(),
     daily_notes = config.DailyNotesOpts.default(),
@@ -51,11 +53,26 @@ end
 ---@return obsidian.config.ClientOpts
 config.ClientOpts.normalize = function(opts)
   opts = vim.tbl_extend("force", config.ClientOpts.default(), opts)
+  opts.backlinks = vim.tbl_extend("force", config.BacklinksOpts.default(), opts.backlinks)
   opts.completion = vim.tbl_extend("force", config.CompletionOpts.default(), opts.completion)
   opts.mappings = opts.mappings and opts.mappings or config.MappingOpts.default()
   opts.daily_notes = vim.tbl_extend("force", config.DailyNotesOpts.default(), opts.daily_notes)
   opts.dir = vim.fs.normalize(tostring(opts.dir))
   return opts
+end
+
+---@class obsidian.config.BacklinksOpts
+---@field height integer
+---@field wrap boolean
+config.BacklinksOpts = {}
+
+---Get defaults.
+---@return obsidian.config.BacklinksOpts
+config.BacklinksOpts.default = function()
+  return {
+    height = 10,
+    wrap = true,
+  }
 end
 
 ---@class obsidian.config.CompletionOpts


### PR DESCRIPTION
Adds `backlinks` section to config. At the moment this will allow users to customize the backlinks pane height and `wrap` setting. Partially addresses #171.
