### PR TITLE
Apply `note_frontmatter_func` when for new notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `template_pattern` not escaping special characters.
 - Fixed new notes not getting passed args correctly
 - Fixed `:ObsidianOpen` when note is in a subdirectory with the same name as the root vault directory.
+- Fixed issue where `note_frontmatter_func` option was not used when creating new notes.
 
 ## [v1.12.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.12.0) - 2023-07-15
 

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -303,7 +303,11 @@ client.new_note = function(self, title, id, dir, aliases)
 
   -- Create Note object and save.
   local note = obsidian.note.new(new_id, aliases, {}, path)
-  note:save(nil, not self.opts.disable_frontmatter)
+  local frontmatter = nil
+  if self.opts.note_frontmatter_func ~= nil then
+    frontmatter = self.opts.note_frontmatter_func(note)
+  end
+  note:save(nil, not self.opts.disable_frontmatter, frontmatter)
   echo.info("Created note " .. tostring(note.id) .. " at " .. tostring(note.path), self.opts.log_level)
 
   return note
@@ -350,7 +354,11 @@ client._daily = function(self, datetime)
   -- Create Note object and save if it doesn't already exist.
   local note = obsidian.note.new(id, { alias }, { "daily-notes" }, path)
   if not note:exists() then
-    note:save(nil, not self.opts.disable_frontmatter)
+    local frontmatter = nil
+    if self.opts.note_frontmatter_func ~= nil then
+      frontmatter = self.opts.note_frontmatter_func(note)
+    end
+    note:save(nil, not self.opts.disable_frontmatter, frontmatter)
     echo.info("Created note " .. tostring(note.id) .. " at " .. tostring(note.path), self.opts.log_level)
   end
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -371,7 +371,8 @@ end
 ---
 ---@param path string|Path|?
 ---@param insert_frontmatter boolean|?
-note.save = function(self, path, insert_frontmatter)
+---@param frontmatter table|?
+note.save = function(self, path, insert_frontmatter, frontmatter)
   if self.path == nil then
     echo.fail "note path cannot be nil"
     error()
@@ -409,7 +410,7 @@ note.save = function(self, path, insert_frontmatter)
   -- Replace frontmatter.
   local new_lines = {}
   if insert_frontmatter ~= false then
-    new_lines = self:frontmatter_lines(true)
+    new_lines = self:frontmatter_lines(true, frontmatter)
   end
 
   -- Add remaining original lines.


### PR DESCRIPTION
Fixes #173

The configuration option `note_frontmatter_func` will now be used when
creating new notes.
