### PR TITLE
Allow spaces in header portion of links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ### Fixed
 
 - A but when following links when headers have a space.
-
-## Unreleased
 
 ## [v1.13.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.13.0) - 2023-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- A but when following links when headers have a space.
+
 ## Unreleased
 
 ## [v1.13.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.13.0) - 2023-08-24

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -571,7 +571,7 @@ command.follow = function(client, _)
   end
 
   -- Remove header link from the end if there is one.
-  local header_link = note_file_name:match "#[%a%d-_]+$"
+  local header_link = note_file_name:match "#[%a%d -_]+$"
   if header_link ~= nil then
     note_file_name = note_file_name:sub(1, -header_link:len() - 1)
   end


### PR DESCRIPTION
I had trouble following links, turns out it was because of a lack of the space character in a regex.