### PR TITLE
ignore '^' in link following, use %s instead to match spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A but when following links when headers have a space.
+- A bug when following links when headers have a space.
+- Fixed `ObsidianFollowLink` when the note path contains a block link (e.g. `[[foo#^Bar]]`).
 
 ## [v1.13.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.13.0) - 2023-08-24
 
@@ -39,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed new notes not getting passed args correctly
 - Fixed `:ObsidianOpen` when note is in a subdirectory with the same name as the root vault directory.
 - Fixed issue where `note_frontmatter_func` option was not used when creating new notes.
-- Fixed `ObsidianFollowLink` when the note path contains a block link (e.g. `[[foo#^Bar]]`).
 
 ## [v1.12.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.12.0) - 2023-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed new notes not getting passed args correctly
 - Fixed `:ObsidianOpen` when note is in a subdirectory with the same name as the root vault directory.
 - Fixed issue where `note_frontmatter_func` option was not used when creating new notes.
+- Fixed `ObsidianFollowLink` when the note path contains a block link (e.g. `[[foo#^Bar]]`).
 
 ## [v1.12.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.12.0) - 2023-07-15
 

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -570,8 +570,8 @@ command.follow = function(client, _)
     return
   end
 
-  -- Remove header link from the end if there is one.
-  local header_link = note_file_name:match "#[%a%d -_]+$"
+  -- Remove links from the end if there are any.
+  local header_link = note_file_name:match "#[%a%d%s-_^]+$"
   if header_link ~= nil then
     note_file_name = note_file_name:sub(1, -header_link:len() - 1)
   end


### PR DESCRIPTION
ignore '^' in link following, so that links to blocks also work as expected.
 use %s instead of ' ' to match spaces, which is the correct way mentioned in the docs, and fixes an existing problem in the previous match expression.
