### PR TITLE
Minor change to behavior of `:ObsidianNew` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Minor change to the behavior of `:ObsidianNew`. The argument to this command can be in one of 3 different forms which determine the behavior of the command:
+  1. A raw title without any path components, e.g. `:ObsidianNew Foo`. In this case the command will pass the title to the `note_id_func` and put the note in the default location.
+  2. A title prefixed by a path component, e.g. `:ObsidianNew notes/Foo`. In this case the command will pass the title "Foo" to the `note_id_func` and put the note in the directory of the path prefix "notes/".
+  3. An exact path, e.g. `:ObsidianNew notes/foo.md`. In this case the command will put the new note at the path given and the title will be inferred from the filename ("foo").
+
 ### Fixed
 
 - A bug when following links when headers have a space.

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -270,7 +270,6 @@ client.new_note = function(self, title, id, dir, aliases)
     -- Pull out any parent dirs from title.
     local parts = vim.split(title, Path.path.sep)
     if #parts > 1 then
-      title_is_path = true
       -- 'title' will just be the final part of the path.
       title = parts[#parts]
       -- Add the other parts to the base_dir.

--- a/test/obsidian/client_spec.lua
+++ b/test/obsidian/client_spec.lua
@@ -14,7 +14,20 @@ local tmp_client = function()
   local dir = Path:new(tmpname .. "-obsidian/")
   dir:mkdir { parents = true }
 
-  return obsidian.new_from_dir(tostring(dir))
+  local client = obsidian.new_from_dir(tostring(dir))
+  client.opts.note_id_func = function(title)
+    local id = ""
+    if title ~= nil then
+      id = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
+    else
+      for _ = 1, 4 do
+        id = id .. string.char(math.random(65, 90))
+      end
+    end
+    return id
+  end
+
+  return client
 end
 
 describe("Client", function()
@@ -41,5 +54,45 @@ describe("Client", function()
 
     local saved_note = Note.from_file(new_note.path)
     assert.is_false(saved_note.has_frontmatter)
+  end)
+
+  it("should parse a title that's a partial path", function()
+    local client = tmp_client()
+    local title, id, path = client:parse_title_id_path "notes/Foo"
+    assert.equals(title, "Foo")
+    assert.equals(id, "foo")
+    assert.equals(tostring(path), tostring(Path:new(client.dir) / "notes" / "foo.md"))
+  end)
+
+  it("should parse a title that's an exact path", function()
+    local client = tmp_client()
+    local title, id, path = client:parse_title_id_path "notes/foo.md"
+    assert.equals(title, "foo")
+    assert.equals(id, "foo")
+    assert.equals(tostring(path), tostring(Path:new(client.dir) / "notes" / "foo.md"))
+  end)
+
+  it("should ignore boundary whitespace when parsing a title", function()
+    local client = tmp_client()
+    local title, id, path = client:parse_title_id_path "notes/Foo  "
+    assert.equals(title, "Foo")
+    assert.equals(id, "foo")
+    assert.equals(tostring(path), tostring(Path:new(client.dir) / "notes" / "foo.md"))
+  end)
+
+  it("should keep whitespace within a path when parsing a title", function()
+    local client = tmp_client()
+    local title, id, path = client:parse_title_id_path "notes/Foo Bar.md"
+    assert.equals(title, "Foo Bar")
+    assert.equals(id, "Foo Bar")
+    assert.equals(tostring(path), tostring(Path:new(client.dir) / "notes" / "Foo Bar.md"))
+  end)
+
+  it("should generate a new id when the title is just a folder", function()
+    local client = tmp_client()
+    local title, id, path = client:parse_title_id_path "notes/"
+    assert.equals(title, nil)
+    assert.equals(#id, 4)
+    assert.equals(tostring(path), tostring(Path:new(client.dir) / "notes" / (id .. ".md")))
   end)
 end)


### PR DESCRIPTION
Fixes #184.

The argument to the `:ObsidianNew` command can now be in one of 3 different forms which determine the behavior of the command:
  1. A raw title without any path components, e.g. `:ObsidianNew Foo`. In this case the command will pass the title to the `note_id_func` and put the note in the default location.
  2. A title prefixed by a path component, e.g. `:ObsidianNew notes/Foo`. In this case the command will pass the title "Foo" to the `note_id_func` and put the note in the directory of the path prefix "notes/".
  3. An exact path, e.g. `:ObsidianNew notes/foo.md`. In this case the command will put the new note at the path given and the title will be inferred from the filename ("foo").
