### PR TITLE
re-add util.find, fixes #200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- A bug introduced in v1.14.0, a missing `util.find` function.
 
 ## [v1.14.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.14.0) - 2023-09-22
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -206,6 +206,36 @@ util.search = function(dir, term, opts)
   end
 end
 
+---Find markdown files in a directory matching a given term. Return an iterator
+---over file names.
+---
+---@param dir string|Path
+---@param term string
+---@return function
+util.find = function(dir, term)
+  local norm_dir = vim.fs.normalize(tostring(dir))
+  local cmd_args = vim.tbl_flatten {
+    util.FIND_CMD,
+    {
+      util.quote(norm_dir),
+    },
+  }
+  local cmd = table.concat(cmd_args, " ")
+
+  local handle = assert(io.popen(cmd, "r"))
+
+  ---Iterator over matches.
+  ---
+  ---@return MatchData|?
+  return function()
+    local line = handle:read "*l"
+    if line == nil then
+      return nil
+    end
+    return line
+  end
+end
+
 ---Create a new unique Zettel ID.
 ---
 ---@return string


### PR DESCRIPTION
As noted at https://github.com/epwalsh/obsidian.nvim/commit/5d3d8d33f6d6d0817221dc69fe1b6e569e1158fe#diff-61259842cecffd56b43df9d90d64c34da595137a482a36ceaf791a9a52dc22e9L192 , 

> @epwalsh I'm trying to track down bustage on my end that's persisting after https://github.com/epwalsh/obsidian.nvim/pull/202.
> 
> I believe you're removing util.find as a function [here](https://github.com/epwalsh/obsidian.nvim/commit/5d3d8d33f6d6d0817221dc69fe1b6e569e1158fe#diff-61259842cecffd56b43df9d90d64c34da595137a482a36ceaf791a9a52dc22e9L192).
> I also believe you're still calling util.find as of 0.14.0 [here](https://github.com/epwalsh/obsidian.nvim/blob/203a40e923e9505bd18143823831fddbd8f1d075/lua/obsidian/init.lua#L198)?
> 
> Am I misreading?

I re-added the `util.find` function using the new `util.FIND_CMD` (`ripgrep`), which fixes my autocomplete bustage.