### PR TITLE
Add overwrite_mappings option to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- The `overwrite_mappings` option, which sets the mappings in the config even if they already exist
+
 ## [v1.14.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.14.1) - 2023-09-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ This is a complete list of all of the options that can be passed to `require("ob
     ["gf"] = require("obsidian.mapping").gf_passthrough(),
   },
 
+  -- Optional, if set to true, the spcified mappings in the `mappings`
+  -- table will overwrite existing ones. Otherwise a warning is printed
+  -- and the mappings are not applied.
+  overwrite_mappings = false,
+
   -- Optional, customize how names/IDs for new notes are created.
   note_id_func = function(title)
     -- Create note IDs in a Zettelkasten format with a timestamp and a suffix.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This is a complete list of all of the options that can be passed to `require("ob
     },
   },
 
-  -- Optional, if set to true, the spcified mappings in the `mappings`
+  -- Optional, if set to true, the specified mappings in the `mappings`
   -- table will overwrite existing ones. Otherwise a warning is printed
   -- and the mappings are not applied.
   overwrite_mappings = false,

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -16,6 +16,7 @@ local config = {}
 ---@field backlinks obsidian.config.BacklinksOpts
 ---@field completion obsidian.config.CompletionOpts
 ---@field mappings obsidian.config.MappingOpts
+---@field overwrite_mappings boolean|?
 ---@field daily_notes obsidian.config.DailyNotesOpts
 ---@field use_advanced_uri boolean|?
 ---@field open_app_foreground boolean|?
@@ -40,6 +41,7 @@ config.ClientOpts.default = function()
     backlinks = config.BacklinksOpts.default(),
     completion = config.CompletionOpts.default(),
     mappings = config.MappingOpts.default(),
+    overwrite_mappings = false,
     daily_notes = config.DailyNotesOpts.default(),
     use_advanced_uri = nil,
     open_app_foreground = false,

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -98,7 +98,7 @@ obsidian.setup = function(opts)
     -- Mappings...
     for mapping_keys, mapping_config in pairs(opts.mappings) do
       local mapping_set_by = vim.fn.mapcheck(mapping_keys, "n")
-      if mapping_set_by == "" then
+      if mapping_set_by == "" or opts.overwrite_mappings then
         vim.keymap.set("n", mapping_keys, mapping_config.action, mapping_config.opts)
       elseif not string.find(mapping_set_by, "obsidian") then
         echo.warn(
@@ -109,7 +109,8 @@ obsidian.setup = function(opts)
             .. "' has been set by: "
             .. mapping_set_by
             .. "\nTo avoid this warning remove the 'gf' mapping in the 'mappings' section of your obsidian.nvim config."
-            .. "\nSee https://github.com/epwalsh/obsidian.nvim/issues/162 for more information.",
+            .. "\nSee https://github.com/epwalsh/obsidian.nvim/issues/162 for more information."
+            .. "\nAlternatively, set the overwrite_mappings option to true.",
           opts.log_level
         )
       end


### PR DESCRIPTION
This PR adds the `overwrite_mappings` option to the config file. Using this option, specified mappings in the `mappings` table in the config can be set even if they already exist.

The related issue is #193.