### PR TITLE
fix runtime errors on validation errors in note.from_lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `overwrite_mappings` option, which sets the mappings in the config even if they already exist
 
+### Fixed
+
+- Eliminated silent runtime errors on validation errors in note.from_lines 
+
 ## [v1.14.2](https://github.com/epwalsh/obsidian.nvim/releases/tag/v1.14.2) - 2023-09-25
 
 ### Fixed

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -218,7 +218,7 @@ note.from_lines = function(lines, path, root)
           if type(v) == "string" then
             id = v
           else
-            echo.warn("Invalid 'id' in frontmatter for " .. path)
+            echo.warn("Invalid 'id' in frontmatter for " .. tostring(path))
           end
         elseif k == "aliases" then
           if type(v) == "table" then
@@ -236,7 +236,7 @@ note.from_lines = function(lines, path, root)
               end
             end
           else
-            echo.warn("Invalid 'aliases' in frontmatter for " .. path)
+            echo.warn("Invalid 'aliases' in frontmatter for " .. tostring(path))
           end
         elseif k == "tags" then
           if type(v) == "table" then
@@ -246,7 +246,7 @@ note.from_lines = function(lines, path, root)
               else
                 echo.warn(
                   "Invalid tag value found in frontmatter for "
-                    .. path
+                    .. tostring(path)
                     .. ". Expected string, found "
                     .. type(tag)
                     .. "."
@@ -256,7 +256,7 @@ note.from_lines = function(lines, path, root)
           elseif type(v) == "string" then
             tags = vim.split(v, " ")
           else
-            echo.warn("Invalid 'tags' in frontmatter for " .. path)
+            echo.warn("Invalid 'tags' in frontmatter for " .. tostring(path))
           end
         else
           if metadata == nil then


### PR DESCRIPTION
This PR fixes a number of runtime problems related to validation errors when reading note data in `note.from_lines`.

Prior to this fix navigating to a note with validation errors would silently fail and instead a new note would be created in the vault root. I this could also be the root cause of https://github.com/epwalsh/obsidian.nvim/issues/176.