### PR TITLE
feat: support unespacing backslash when following wikilinks

### DIFF
--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -546,6 +546,9 @@ command.follow = function(client, _)
   end
 
   local note_name = current_line:sub(open, close)
+
+  note_name = util.unescape_single_backslash(note_name)
+
   if note_name:match "^%[.-%]%(.*%)$" then
     -- transform markdown link to wiki link
     note_name = note_name:gsub("^%[(.-)%]%((.*)%)$", "%2|%1")

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -660,4 +660,9 @@ util.gf_passthrough = function()
   end
 end
 
+-- This function removes a single backslash within double square brackets
+util.unescape_single_backslash = function(text)
+  return text:gsub("(%[%[[^\\]+)\\(%|[^\\]+]])", "%1%2")
+end
+
 return util

--- a/test/obsidian/util_spec.lua
+++ b/test/obsidian/util_spec.lua
@@ -89,4 +89,9 @@ describe("obsidian.util", function()
     assert.equal(util.escape_magic_characters "foo?bar", "foo%?bar")
     assert.equal(util.escape_magic_characters "foo%bar", "foo%%bar")
   end)
+  it("should correctly remove single backslash", function()
+    -- [[123\|NOTE1]] should get [[123|NOTE1]] in markdown file
+    -- in lua, it needs to be with double backslash '\\'
+    assert.equal(util.unescape_single_backslash "[[foo\\|bar]]", "[[foo|bar]]")
+  end)
 end)

--- a/test/obsidian/util_spec.lua
+++ b/test/obsidian/util_spec.lua
@@ -92,6 +92,6 @@ describe("obsidian.util", function()
   it("should correctly remove single backslash", function()
     -- [[123\|NOTE1]] should get [[123|NOTE1]] in markdown file
     -- in lua, it needs to be with double backslash '\\'
-    assert.equal(util.unescape_single_backslash "[[foo\\|bar]]", "[[foo|bar]]")
+    assert.equals(util.unescape_single_backslash "[[foo\\|bar]]", "[[foo|bar]]")
   end)
 end)


### PR DESCRIPTION
Hi everyone, appreciate the work being done here. I currently have a use case to include wikilinks within a table, however seems like the passthrough (gf) does not work as intended. I made some changes to make it work, and if this is something that can be part of the project, please let me know, happy to contribute.

## Changes:
Allow user to escape wikilink in certain case, e.g. within a table. The code did not alter anything, but just add a check to remove backslash if needed.

## Example:
| Column1  | Column2                  | Column3 |
| --------- | ------------------- | --------- |
| Item1       | [[NOTE-ID\\|TITLE]] | Item1       |

The wikilink should be able to follow, without the '\', some auto format might go crazy by treating the '|' as column separator.