### PR TITLE
Refactor workspaces

### DIFF
--- a/lua/obsidian/backlinks.lua
+++ b/lua/obsidian/backlinks.lua
@@ -123,7 +123,7 @@ Backlinks._gather = function(self)
   local tx, rx = channel.oneshot()
 
   -- Collect matches.
-  search.search_async(self.client.dir, "[[" .. tostring(self.note.id), opts, function(match)
+  search.search_async(self.client.current_workspace.path, "[[" .. tostring(self.note.id), opts, function(match)
     if is_valid_backlink(match) then
       local path = match.path.text
 
@@ -152,7 +152,7 @@ Backlinks._gather = function(self)
   -- Load notes for each match and combine into array of BacklinksMatches.
   local executor = AsyncExecutor.new()
   executor:map(function(path, idx)
-    local ok, res = pcall(Note.from_file_async, path, self.client.dir)
+    local ok, res = pcall(Note.from_file_async, path, self.client.current_workspace.path)
     if ok then
       out[idx] = { note = res, matches = backlink_matches[path] }
     else

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -45,7 +45,7 @@ Client.new = function(opts)
     _, default_workspace = next(self.workspaces)
   end
 
-  self:switch_workspace(default_workspace, opts)
+  self:switch_workspace(default_workspace)
 
   -- temporary
   self.dir = default_workspace.path
@@ -743,8 +743,9 @@ Client.update_ui = function(self, bufnr)
 end
 
 --- switch the current workspace
+---@param self obsidian.Client
 ---@param workspace obsidian.Workspace
-Client.switch_workspace = function(self, workspace, opts)
+Client.switch_workspace = function(self, workspace)
   if self.current_workspace ~= nil
   then
     self.current_workspace:clear()
@@ -755,7 +756,7 @@ Client.switch_workspace = function(self, workspace, opts)
   -- Register mappings.
   workspace:register(
     function()
-      for mapping_keys, mapping_config in pairs(opts.mappings) do
+      for mapping_keys, mapping_config in pairs(self.opts.mappings) do
         vim.keymap.set("n", mapping_keys, mapping_config.action, mapping_config.opts)
       end
     end)
@@ -769,13 +770,13 @@ Client.switch_workspace = function(self, workspace, opts)
   -- Inject Obsidian as a cmp source when reading a buffer in the vault.
   workspace:register(
     function()
-      if opts.completion.nvim_cmp then
+      if self.opts.completion.nvim_cmp then
         local cmp = require "cmp"
 
         local sources = {
-          { name = "obsidian",      option = opts },
-          { name = "obsidian_new",  option = opts },
-          { name = "obsidian_tags", option = opts },
+          { name = "obsidian",      option = self.opts },
+          { name = "obsidian_new",  option = self.opts },
+          { name = "obsidian_tags", option = self.opts },
         }
         for _, source in pairs(cmp.get_config().sources) do
           if source.name ~= "obsidian" and source.name ~= "obsidian_new" and source.name ~= "obsidian_tags" then

--- a/lua/obsidian/command.lua
+++ b/lua/obsidian/command.lua
@@ -808,7 +808,7 @@ M.register("ObsidianWorkspace", {
       return
     end
 
-    client.current_workspace = workspace
+    client:switch_workspace(workspace)
 
     log.info("Switching to workspace '" .. workspace.name .. "' (" .. workspace.path .. ")")
     -- NOTE: workspace.path has already been normalized

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -118,15 +118,25 @@ config.ClientOpts.normalize = function(opts)
     opts.overwrite_mappings = nil
   end
 
-  -- Normalize workspace paths.
+  -- Normalize workspaces
+  -- NOTE: path will be normalized in workspace.new*() fn
   for key, value in pairs(opts.workspaces) do
-    opts.workspaces[key].path = vim.fs.normalize(tostring(value.path))
+    if value.path == nil
+    then
+      log.warn("encountered an invalid workspace: path is nil")
+    end
+    if value.name == nil
+    then
+      opts.workspaces[key] = workspace.new_from_dir(value.path)
+    else
+      opts.workspaces[key] = workspace.new(value.name, value.path)
+    end
   end
 
   -- Convert dir to workspace format.
+  -- NOTE: path will be normalized in workspace.new_from_dir() fn
   if opts.dir ~= nil then
-    -- NOTE: path will be normalized in workspace.new() fn
-    table.insert(opts.workspaces, 1, workspace.new("dir", opts.dir))
+    table.insert(opts.workspaces, 1, workspace.new_from_dir(opts.dir))
   end
 
   return opts

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -175,36 +175,6 @@ obsidian.setup = function(opts)
   -- Register autocommands.
   local group = vim.api.nvim_create_augroup("obsidian_setup", { clear = true })
 
-  -- Only register commands, mappings, cmp source, etc when we enter a note buffer.
-  vim.api.nvim_create_autocmd({ "BufEnter" }, {
-    group = group,
-    pattern = tostring(client.dir / "**.md"),
-    callback = function()
-      -- Register mappings.
-      for mapping_keys, mapping_config in pairs(opts.mappings) do
-        vim.keymap.set("n", mapping_keys, mapping_config.action, mapping_config.opts)
-      end
-
-      vim.cmd [[ setlocal suffixesadd+=.md ]]
-
-      if opts.completion.nvim_cmp then
-        -- Inject Obsidian as a cmp source when reading a buffer in the vault.
-        local cmp = require "cmp"
-
-        local sources = {
-          { name = "obsidian", option = opts },
-          { name = "obsidian_new", option = opts },
-          { name = "obsidian_tags", option = opts },
-        }
-        for _, source in pairs(cmp.get_config().sources) do
-          if source.name ~= "obsidian" and source.name ~= "obsidian_new" and source.name ~= "obsidian_tags" then
-            table.insert(sources, source)
-          end
-        end
-        cmp.setup.buffer { sources = sources }
-      end
-    end,
-  })
 
   -- Add/update frontmatter on BufWritePre
   vim.api.nvim_create_autocmd({ "BufWritePre" }, {

--- a/lua/obsidian/search.lua
+++ b/lua/obsidian/search.lua
@@ -306,7 +306,6 @@ end
 ---@return string[]
 M.build_find_cmd = function(path, term, opts)
   opts = SearchOpts.from_tbl(opts and opts or {})
-
   local additional_opts = {}
 
   if term ~= nil then

--- a/lua/obsidian/templates.lua
+++ b/lua/obsidian/templates.lua
@@ -74,7 +74,8 @@ M.insert_template = function(name, client, location)
   end
   local buf, win, row, col = unpack(location)
   local template_path = Path:new(client.templates_dir) / name
-  local title = require("obsidian.note").from_buffer(buf, client.dir):display_name()
+  -- FIXME: Temporarily change client.dir to client.current_workspace.path
+  local title = require("obsidian.note").from_buffer(buf, client.current_workspace.path):display_name()
 
   local insert_lines = {}
   local template_file = io.open(tostring(template_path), "r")

--- a/lua/obsidian/workspace.lua
+++ b/lua/obsidian/workspace.lua
@@ -25,61 +25,12 @@ Workspace.new = function(name, path)
   return self
 end
 
-Workspace.new_from_cwd = function()
-  return Workspace.new_from_dir(vim.fn.getcwd())
-end
-
 ---Create new workspace
 --
 ---@param dir string
 ---@return obsidian.Workspace
 Workspace.new_from_dir = function(dir)
   return Workspace.new(vim.fn.fnamemodify(dir, ":t"), dir)
-end
-
----Determines if cwd is a workspace
----
----@param workspaces table<obsidian.Workspace>
----@return obsidian.Workspace|nil
-Workspace.get_workspace_from_cwd = function(workspaces)
-  local cwd = vim.fn.getcwd()
-  local _, value = next(vim.tbl_filter(function(w)
-    if w.path == cwd then
-      return true
-    end
-    return false
-  end, workspaces))
-
-  return value
-end
-
----Returns the default workspace
----
----@param workspaces table<obsidian.Workspace>
----@return obsidian.Workspace|nil
-Workspace.get_default_workspace = function(workspaces)
-  local _, value = next(workspaces)
-  return value
-end
-
----Resolves current workspace from client config
----
----@param opts obsidian.config.ClientOpts
----@return obsidian.Workspace
-Workspace.get_from_opts = function(opts)
-  local current_workspace
-
-  if opts.detect_cwd then
-    current_workspace = Workspace.get_workspace_from_cwd(opts.workspaces)
-  else
-    current_workspace = Workspace.get_default_workspace(opts.workspaces)
-  end
-
-  if not current_workspace then
-    current_workspace = Workspace.new_from_cwd()
-  end
-
-  return current_workspace
 end
 
 --- register `cb` to be called whenever a buffer from this workspace is entered

--- a/lua/obsidian/workspace.lua
+++ b/lua/obsidian/workspace.lua
@@ -1,8 +1,9 @@
 local abc = require "obsidian.abc"
+local Path = require "plenary.path"
 
 ---@class obsidian.Workspace : obsidian.ABC
 ---@field name string
----@field path string
+---@field path Path
 ---@field group number autocommand group id, used by `Workspace.register`
 local Workspace = abc.new_class {
   __tostring = function(self)
@@ -19,7 +20,7 @@ local Workspace = abc.new_class {
 Workspace.new = function(name, path)
   local self = Workspace.init()
   self.name = name
-  self.path = vim.fs.normalize(path)
+  self.path = Path:new(vim.fs.normalize(path))
   self.group = vim.api.nvim_create_augroup("obsidian_workspace_" .. string.lower(name), { clear = true })
   return self
 end

--- a/lua/obsidian/workspace.lua
+++ b/lua/obsidian/workspace.lua
@@ -3,6 +3,7 @@ local abc = require "obsidian.abc"
 ---@class obsidian.Workspace : obsidian.ABC
 ---@field name string
 ---@field path string
+---@field group number autocommand group id, used by `Workspace.register`
 local Workspace = abc.new_class {
   __tostring = function(self)
     return string.format("Workspace('%s', '%s')", self.name, self.path)
@@ -19,6 +20,7 @@ Workspace.new = function(name, path)
   local self = Workspace.init()
   self.name = name
   self.path = vim.fs.normalize(path)
+  self.group = vim.api.nvim_create_augroup("obsidian_workspace_" .. string.lower(name), { clear = true })
   return self
 end
 
@@ -26,6 +28,10 @@ Workspace.new_from_cwd = function()
   return Workspace.new_from_dir(vim.fn.getcwd())
 end
 
+---Create new workspace
+--
+---@param dir string
+---@return obsidian.Workspace
 Workspace.new_from_dir = function(dir)
   return Workspace.new(vim.fn.fnamemodify(dir, ":t"), dir)
 end
@@ -73,6 +79,25 @@ Workspace.get_from_opts = function(opts)
   end
 
   return current_workspace
+end
+
+--- register `cb` to be called whenever a buffer from this workspace is entered
+--- all callbacks can be cleared with `Workspace:clear()`
+---@param self obsidian.Workspace
+---@param cb fun(cb: fun(event:any))
+Workspace.register = function(self, cb)
+  vim.api.nvim_create_autocmd({ "BufEnter" }, {
+    group = self.group,
+    pattern = tostring(self.path / "**.md"),
+    callback = cb
+  })
+end
+
+--- Clear autocommands
+---
+---@param self obsidian.Workspace
+Workspace.clear = function(self)
+  vim.api.nvim_clear_autocmds({ group = self.group })
 end
 
 return Workspace


### PR DESCRIPTION
this is a draft PR to decide how to go about this.
- clients must not attach to any specific root vault
  - clients must have a set of vaults (`client.workspaces`) and a currently used vault (`client.current_workspace`).
  - `client.dir` must be removed, use `.current_workspace`
  - `workspace.path` should be of type `plenary.path` if it's going to replace `client.dir`
  - `client:vault_root` should be removed
  - `obsidian.new_from_dir` should be removed
  - get rid of `templates_dir` as well ? this needs discussion
- auto command registration and clearing should happen through the workflow module, maybe `workflow:register(callback)` and `workflow:clear()`.
- we should simplify the `detect_cwd` logic: `Workspace.new_from_cwd`, `Workspace.get_workspace_from_cwd`, and `Workspace.get_default_workspace` only call each other and are not used by any other modules, the separation of the logic into these different functions unnecessary.
- we should figure out a way to deal with templates:
  from https://github.com/epwalsh/obsidian.nvim/issues/190#issuecomment-1837511113:
  > - should templates be read at some chosen "main vault" root directory (the way it's done right now)
  > - or should it be read relative to the current workspace ?
  > - or should it be a per-workspace option: `{name="foo", path="bar", template_configs..}` ?
