### PR TITLE
Fix: Fixed a bug with :ObsidianFollowLink where new notes were always created at the vault's root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-- Fixed a bug with :ObsidianFollowLink where new notes were always created at the vault's root.
+### Changed
+
+- Creating new notes via `:ObsidianFollowLink` now matches the behavior of `:ObsidianLinkNew`, where the new note will be placed in the same directory as the current buffer note. This doesn't affect you if you use a flat directory structure for all of your notes.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed a bug with :ObsidianFollowLink where new notes were always created at the vault's root.
+
 ### Added
 
 - `:ObsidianFollowLink` now takes an optional "open strategy" argument. For example `:ObsidianFollowLink vsplit` or `:ObsidianFollowLink vsp` opens the note in a vertical split.

--- a/lua/obsidian/commands/follow_link.lua
+++ b/lua/obsidian/commands/follow_link.lua
@@ -45,7 +45,7 @@ return function(client, data)
         if confirmation == "y" or confirmation == "yes" then
           -- Create a new note.
           local aliases = name == location and {} or { name }
-          note = client:new_note(location, nil, vim.fn.expand "%:p:h", aliases)
+          note = client:new_note(location, nil, client.buf_dir, aliases)
           vim.api.nvim_command(open_cmd .. tostring(note.path))
         else
           log.warn "Aborting"

--- a/lua/obsidian/commands/follow_link.lua
+++ b/lua/obsidian/commands/follow_link.lua
@@ -45,7 +45,7 @@ return function(client, data)
         if confirmation == "y" or confirmation == "yes" then
           -- Create a new note.
           local aliases = name == location and {} or { name }
-          note = client:new_note(location, nil, vim.fn.expand("%:p:h"), aliases)
+          note = client:new_note(location, nil, vim.fn.expand "%:p:h", aliases)
           vim.api.nvim_command(open_cmd .. tostring(note.path))
         else
           log.warn "Aborting"

--- a/lua/obsidian/commands/follow_link.lua
+++ b/lua/obsidian/commands/follow_link.lua
@@ -45,7 +45,7 @@ return function(client, data)
         if confirmation == "y" or confirmation == "yes" then
           -- Create a new note.
           local aliases = name == location and {} or { name }
-          note = client:new_note(location, nil, nil, aliases)
+          note = client:new_note(location, nil, vim.fn.expand("%:p:h"), aliases)
           vim.api.nvim_command(open_cmd .. tostring(note.path))
         else
           log.warn "Aborting"

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -50,7 +50,7 @@ M.register = function(name, config)
     config.func = function(client, data)
       return M[name](client, data)
     end
-  end
+ ObsidianFollowLink end
   M.commands[name] = config
 end
 

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -50,7 +50,7 @@ M.register = function(name, config)
     config.func = function(client, data)
       return M[name](client, data)
     end
- ObsidianFollowLink end
+end
   M.commands[name] = config
 end
 

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -50,7 +50,7 @@ M.register = function(name, config)
     config.func = function(client, data)
       return M[name](client, data)
     end
-end
+  end
   M.commands[name] = config
 end
 

--- a/lua/obsidian/commands/link_new.lua
+++ b/lua/obsidian/commands/link_new.lua
@@ -24,7 +24,7 @@ return function(client, data)
   else
     title = string.sub(line, cscol, cecol)
   end
-  local note = client:new_note(title, nil, vim.fn.expand "%:p:h")
+  local note = client:new_note(title, nil, client.buf_dir)
 
   line = string.sub(line, 1, cscol - 1)
     .. "[["


### PR DESCRIPTION
When creating note through `: ObsidianLinkNew` the note is created in the current buffer directory while when using `ObsidianFollowLink` on a "undefined" note and responding `Yes` to the prompt, the note was created in the vault's root. 

I opted to align the behavior with the `:ObsidianLinkNew` functionality.