### PR TITLE
Accept no input as a default "yes" for prompts

### DIFF
--- a/lua/obsidian/commands/follow_link.lua
+++ b/lua/obsidian/commands/follow_link.lua
@@ -42,7 +42,7 @@ return function(client, data)
         local confirmation = string.lower(vim.fn.input {
           prompt = "Create new note '" .. location .. "'? [Y/n] ",
         })
-        if confirmation == "y" or confirmation == "yes" then
+        if confirmation == "" or confirmation == "y" or confirmation == "yes" then
           -- Create a new note.
           local aliases = name == location and {} or { name }
           note = client:new_note(location, nil, client.buf_dir, aliases)

--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -99,7 +99,7 @@ return function(client, data)
         .. "Do you want to continue? [Y/n] ",
     })
   end
-  if not (confirmation == "y" or confirmation == "yes") then
+  if not (confirmation == "" or confirmation == "y" or confirmation == "yes") then
     log.warn "Rename canceled, doing nothing"
     return
   end

--- a/lua/obsidian/img_paste.lua
+++ b/lua/obsidian/img_paste.lua
@@ -122,7 +122,7 @@ M.paste_img = function(fname, default_dir)
     local confirmation = string.lower(vim.fn.input {
       prompt = "Saving image to '" .. tostring(path) .. "'. Do you want to continue? [Y/n] ",
     })
-    if not (confirmation == "y" or confirmation == "yes") then
+    if not (confirmation == "" or confirmation == "y" or confirmation == "yes") then
       log.warn "Paste canceled"
       return
     end


### PR DESCRIPTION
The capital `Y` in the prompt implies that it is the default if the
user inputs nothing and presses enter (typically). I think it would
be safe to assume that should be the behavior here too, and saves
the user keystrokes.
