### PR TITLE
Improve UX of conceallevel UI warning

### DIFF
--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -567,19 +567,29 @@ M.setup = function(ui_opts)
     return
   end
 
-  local conceallevel = vim.opt_local.conceallevel:get()
-  if conceallevel < 1 or conceallevel > 2 then
-    log.warn(
-      "Obsidian additional syntax features require 'conceallevel' to be set to 1 or 2, "
-        .. "but you have 'conceallevel' set to '%s'.\n"
-        .. "See https://github.com/epwalsh/obsidian.nvim/issues/286 for more details.",
-      conceallevel
-    )
-  end
-
   local group = vim.api.nvim_create_augroup("obsidian_ui", { clear = true })
 
   install_hl_groups(ui_opts)
+
+  vim.api.nvim_create_autocmd({ "BufEnter" }, {
+    group = group,
+    pattern = "*.md",
+    callback = function()
+      local conceallevel = vim.opt_local.conceallevel:get()
+
+      if conceallevel < 1 or conceallevel > 2 then
+        log.warn(
+          "Obsidian additional syntax features require 'conceallevel' to be set to 1 or 2, "
+            .. "but you have 'conceallevel' set to '%s'.\n"
+            .. "See https://github.com/epwalsh/obsidian.nvim/issues/286 for more details.",
+          conceallevel
+        )
+      end
+
+      -- delete the autocommand
+      return true
+    end,
+  })
 
   vim.api.nvim_create_autocmd({ "BufEnter" }, {
     group = group,


### PR DESCRIPTION
With the current implementation, the warning is always shown under the following conditions:

- `conceallevel` is something other than `1` or `2` globally
- the user sets `conceallevel = 1 | 2` locally for markdown files, but opens Neovim with a buffer that is not markdown

This can be cumbersome if:

- the user's config runs `obsidian.setup` in a non-Obsidian repo and `conceallevel` is not 1 or 2
- the user sets `conceallevel` for markdown files only, but opens Neovim in an Obsidian repo on a non-markdown file

This PR addresses these scenarios by:

- using an autocommand to assert `conceallevel` on `BufEnter` _only_ for markdown files
- only runs the autocommand once per call of `obsidian.setup`

ref #286 

EDIT: add friction points, add ref to issue where warning was added