### PR TITLE
Add extmarks for bullet marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added extmarks that conceal "-" with "•" by default. This can turned off by setting `.ui.bullets` to `nil` in your config.
+
 ## [v2.6.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v2.6.0) - 2024-01-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ This is a complete list of all of the options that can be passed to `require("ob
 
       -- You can also add more custom ones...
     },
+    -- Use bullet marks for non-checkbox lists.
+    bullets = { char = "•", hl_group = "ObsidianBullet" },
     external_link_icon = { char = "", hl_group = "ObsidianExtLinkIcon" },
     -- Replace the above with this if you don't have a patched font:
     -- external_link_icon = { char = "", hl_group = "ObsidianExtLinkIcon" },
@@ -420,6 +422,7 @@ This is a complete list of all of the options that can be passed to `require("ob
       ObsidianDone = { bold = true, fg = "#89ddff" },
       ObsidianRightArrow = { bold = true, fg = "#f78c6c" },
       ObsidianTilde = { bold = true, fg = "#ff5370" },
+      ObsidianBullet = { bold = true, fg = "#89ddff" },
       ObsidianRefText = { underline = true, fg = "#c792ea" },
       ObsidianExtLinkIcon = { fg = "#c792ea" },
       ObsidianTag = { italic = true, fg = "#89ddff" },

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -248,6 +248,7 @@ end
 ---@field tick integer
 ---@field update_debounce integer
 ---@field checkboxes table{string, obsidian.config.UICharSpec}
+---@field bullets obsidian.config.UICharSpec|?
 ---@field external_link_icon obsidian.config.UICharSpec
 ---@field reference_text obsidian.config.UIStyleSpec
 ---@field highlight_text obsidian.config.UIStyleSpec
@@ -273,6 +274,7 @@ config.UIOpts.default = function()
       [">"] = { char = "", hl_group = "ObsidianRightArrow" },
       ["~"] = { char = "󰰱", hl_group = "ObsidianTilde" },
     },
+    bullets = { char = "•", hl_group = "ObsidianBullet" },
     external_link_icon = { char = "", hl_group = "ObsidianExtLinkIcon" },
     reference_text = { hl_group = "ObsidianRefText" },
     highlight_text = { hl_group = "ObsidianHighlightText" },
@@ -282,6 +284,7 @@ config.UIOpts.default = function()
       ObsidianDone = { bold = true, fg = "#89ddff" },
       ObsidianRightArrow = { bold = true, fg = "#f78c6c" },
       ObsidianTilde = { bold = true, fg = "#ff5370" },
+      ObsidianBullet = { bold = true, fg = "#89ddff" },
       ObsidianRefText = { underline = true, fg = "#c792ea" },
       ObsidianExtLinkIcon = { fg = "#c792ea" },
       ObsidianTag = { italic = true, fg = "#89ddff" },

--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -202,9 +202,25 @@ local function get_line_check_extmarks(marks, line, lnum, ui_opts)
           hl_group = opts.hl_group,
         }
       )
-      break
+      return marks
     end
   end
+
+  if ui_opts.bullets ~= nil and string.match(line, "^%s*- ") then
+    local indent = util.count_indent(line)
+    marks[#marks + 1] = ExtMark.new(
+      nil,
+      lnum,
+      indent,
+      ExtMarkOpts.from_tbl {
+        end_row = lnum,
+        end_col = indent + 1,
+        conceal = ui_opts.bullets.char,
+        hl_group = ui_opts.bullets.hl_group,
+      }
+    )
+  end
+
   return marks
 end
 


### PR DESCRIPTION
Replaces "-" with "•" for non-checkbox list items like the Obsidian app does.
See https://github.com/epwalsh/obsidian.nvim/discussions/310
