### PR TITLE
Fix bug with `Client:vault_relative_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added extmarks that conceal "-" with "•" by default. This can turned off by setting `.ui.bullets` to `nil` in your config.
 
+### Fixed
+
+- Fixed bug with resolving the vault-relative path when the vault is behind a symlink.
+
 ## [v2.6.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v2.6.0) - 2024-01-09
 
 ### Changed

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -179,7 +179,7 @@ Client.vault_relative_path = function(self, path)
     -- `path` and remove everything up to and including it.
     local _, j = string.find(relative_path, self:vault_name())
     if j ~= nil then
-      return string.sub(relative_path, j)
+      return string.sub(relative_path, j + 2)
     else
       return relative_path
     end


### PR DESCRIPTION
Fixes bug with resolving the vault-relative path when the vault is behind a symlink (closes #318).
