### PR TITLE
fix for powershell command for ObsidianPasteImg on wsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed powershell command for :ObsidianPasteImg in wsl
+
 ## [v2.7.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v2.7.0) - 2024-01-19
 
 ### Fixed

--- a/lua/obsidian/img_paste.lua
+++ b/lua/obsidian/img_paste.lua
@@ -71,11 +71,8 @@ local function save_clipboard_image(path)
       return result
     end
   elseif this_os == util.OSType.Windows or this_os == util.OSType.Wsl then
-    local cmd = 'powershell.exe "'
-      .. string.format(
-        "$content = Get-Clipboard -Format Image;$content.Save('%s', 'png')",
-        string.gsub(path, "/", "\\")
-      )
+    local cmd = 'powershell.exe -c "'
+      .. string.format("(get-clipboard -format image).save('%s', 'png')", string.gsub(path, "/", "\\"))
       .. '"'
     return os.execute(cmd)
   elseif this_os == util.OSType.Darwin then


### PR DESCRIPTION
I'm no powershell expert, but on my machine, I wasn't able to get any powershell "remote" command to work with "$content" style variables. I fiddled with the powershell command until I got it working. 

One additional issue which this unearthed: it seems that only links which match a url pattern are considered "external" links, so when you "gf" on the resulting png link from this fix, you get the raw png opened up in a buffer. Probably not ideal. Can we maybe allow the use of "follow_url_func" to be expanded to any external link, and not just urls? 