### PR TITLE
Add description to toggle_checkbox keymap opts

### DIFF
--- a/lua/obsidian/mappings.lua
+++ b/lua/obsidian/mappings.lua
@@ -12,7 +12,7 @@ M.gf_passthrough = function()
 end
 
 M.toggle_checkbox = function()
-  return { action = util.toggle_checkbox, opts = { buffer = true } }
+  return { action = util.toggle_checkbox, opts = { buffer = true, desc = "Toggle Checkbox" } }
 end
 
 return M


### PR DESCRIPTION
This just adds a default description for the toggle_checkbox keymap for those
using `which-key` and the like.
