### PR TITLE
insert_link action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added client method `Client:format_link()` for creating markdown / wiki links.
+- Added telescope action to insert a note link in certain finder scenarios.
 
 ## [v2.9.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v2.9.0) - 2024-01-31
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ This is a complete list of all of the options that can be passed to `require("ob
     --  * "notes_subdir" - put new notes in the default notes subdirectory.
     new_notes_location = "current_dir",
 
+    -- Either 'wiki' or 'markdown'.
+    preferred_link_style = "wiki",
+
     -- Control how wiki links are completed with these (mutually exclusive) options:
     --
     -- 1. Whether to add the note ID during completion.

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1120,6 +1120,8 @@ end
 ---
 ---@return string
 Client.format_link = function(self, note, opts)
+  opts = opts and opts or {}
+
   ---@type string, string, string|?
   local rel_path, label, note_id
   if type(note) == "string" then

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -217,7 +217,7 @@ config.FinderMappingOpts = {}
 config.FinderMappingOpts.default = function()
   return {
     new = "<C-x>",
-    insert_link = "<C-i>",
+    insert_link = "<C-l>",
   }
 end
 

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -175,6 +175,7 @@ config.LinkStyle = {
 ---@field prepend_note_id boolean
 ---@field prepend_note_path boolean
 ---@field use_path_only boolean
+---@field perferred_link_style obsidian.config.LinkStyle
 config.CompletionOpts = {}
 
 ---Get defaults.
@@ -188,6 +189,7 @@ config.CompletionOpts.default = function()
     prepend_note_id = true,
     prepend_note_path = false,
     use_path_only = false,
+    preferred_link_style = config.LinkStyle.wiki,
   }
 end
 
@@ -207,6 +209,7 @@ end
 
 ---@class obsidian.config.FinderMappingOpts
 ---@field new string|?
+---@field insert_link string|?
 config.FinderMappingOpts = {}
 
 ---Get defaults.
@@ -214,6 +217,7 @@ config.FinderMappingOpts = {}
 config.FinderMappingOpts.default = function()
   return {
     new = "<C-x>",
+    insert_link = "<C-i>",
   }
 end
 

--- a/lua/obsidian/picker_utils.lua
+++ b/lua/obsidian/picker_utils.lua
@@ -16,12 +16,26 @@ M.telescope_mappings = function(map, client, initial_query)
       require("telescope.actions").close(prompt_bufnr)
       client:command("ObsidianNew", { args = query })
     end,
+
+    obsidian_insert_link = function(prompt_bufnr)
+      require("telescope.actions").close(prompt_bufnr)
+      local path = require("telescope.actions.state").get_selected_entry().path
+      local note = require("obsidian").Note.from_file(path, client.dir)
+      local link = client:format_link(note, {})
+      vim.api.nvim_put({ link }, "", false, true)
+    end,
   }
 
   local new_mapping = client.opts.finder_mappings.new
   if new_mapping ~= nil then
     map({ "i", "n" }, new_mapping, telescope_actions.obsidian_new)
   end
+
+  local insert_link_mapping = client.opts.finder_mappings.insert_link
+  if insert_link_mapping ~= nil then
+    map({ "i", "n" }, insert_link_mapping, telescope_actions.obsidian_insert_link)
+  end
+
   return true
 end
 
@@ -34,6 +48,10 @@ M.telescope_prompt_title = function(name, client)
   local keys = client.opts.finder_mappings.new
   if keys ~= nil then
     prompt_title = prompt_title .. " | " .. keys .. " new"
+  end
+  keys = client.opts.finder_mappings.insert_link
+  if keys ~= nil then
+    prompt_title = prompt_title .. " | " .. keys .. " insert link"
   end
   return prompt_title
 end


### PR DESCRIPTION
Minimal implementation for feature request #360, probably not production ready.
I closed my previous related pull request #364 because I forgot to create a feature branch for this, sorry.

Not sure if the following is necessary: `local note_id = require('obsidian').Note.from_file(rel_path .. ".md", client.dir).id`. I think in most cases the id of a note is just the part of the filename after the last `/` without the extension? So maybe a regex would do to extract the id from the filename?

To be honest, I'm just starting to explore the concept of note taking in Obsidian, so I'm not sure the feature in this pull request is added value. Feel free to change/close if necessary.

