### PR TITLE
feat(note): title field to provide more flexibility for note_frontmatter_func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added note field `Note.title` to provide more useful info for `note_frontmatter_func`.
+
+### Added
+
 - Added client method `Client:format_link()` for creating markdown / wiki links.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added note field `Note.title` to provide more useful info for `note_frontmatter_func`.
-
-### Added
-
 - Added client method `Client:format_link()` for creating markdown / wiki links.
 
 ### Fixed

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -18,6 +18,7 @@ local SKIP_UPDATING_FRONTMATTER = { "README.md", "CONTRIBUTING.md", "CHANGELOG.m
 ---
 ---@field id string|integer
 ---@field aliases string[]
+---@field title string|?
 ---@field tags string[]
 ---@field path Path|?
 ---@field metadata table|?
@@ -390,6 +391,7 @@ Note.from_lines = function(lines, path, root)
   assert(id)
 
   local n = Note.new(id, aliases, tags, path)
+  n.title = title
   n.metadata = metadata
   n.has_frontmatter = has_frontmatter
   n.frontmatter_end_line = frontmatter_end_line


### PR DESCRIPTION
Provides the user more info for note_frontmatter_func.

My usecase was to learn it behave like linter plugin via its `linter-yaml-title-alias` property to replace previous title alias instead of leaving it as it is