### PR TITLE
🐛 Only update frontmatter if it has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed parsing header with trailing whitespace (https://github.com/epwalsh/obsidian.nvim/issues/341#issuecomment-1925445271).
+- Fixed unnecessary frontmatter update when no change needed
 
 ## [v2.9.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v2.9.0) - 2024-01-31
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -570,6 +570,11 @@ Note.save_to_buffer = function(self, bufnr, frontmatter)
     cur_lines = vim.api.nvim_buf_get_lines(bufnr, 0, cur_buf_note.frontmatter_end_line, false)
   end
 
+  local unchanged = vim.deep_equal(cur_lines, new_lines)
+  if unchanged then
+    return false
+  end
+
   vim.api.nvim_buf_set_lines(
     bufnr,
     0,
@@ -578,7 +583,7 @@ Note.save_to_buffer = function(self, bufnr, frontmatter)
     new_lines
   )
 
-  return not vim.deep_equal(cur_lines, new_lines)
+  return true
 end
 
 return Note


### PR DESCRIPTION
Fixes https://github.com/epwalsh/obsidian.nvim/issues/386

With frontmatter support enabled, the undo history is populated with empty changes which are the updates to the YAML frontmatter with no change. This causes vim undo to not operate as expected.

This fix only makes the frontmatter change if there is actually a change to make.