### PR TITLE
feat: ObsidianExtractNote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `:ObsidianLinks` command.
+- Added `:ObsidianEctractNote` command.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ _Keep in mind this plugin is not meant to replace Obsidian, but to complement it
 
 - `:ObsidianLinks` to collect all links within the current buffer into a picker window.
 
+- `:ObsidianExtractNote` to extract the visually selected text into a new note and link to it.
+
 - `:ObsidianWorkspace [NAME]` to switch to another workspace.
 
 - `:ObsidianPasteImg [IMGNAME]` to paste an image from the clipboard into the note at the cursor position by saving it to the vault and adding a markdown image link. You can configure the default folder to save images to with the `attachments.img_folder` option.

--- a/lua/obsidian/commands/extract_note.lua
+++ b/lua/obsidian/commands/extract_note.lua
@@ -1,0 +1,40 @@
+local log = require "obsidian.log"
+local util = require "obsidian.util"
+
+---Extract the selected text into a new note
+---and replace the selection with a link to the new note.
+---
+---@param client obsidian.Client
+return function(client, data)
+  local viz = util.get_visual_selection()
+  if viz.lines == nil or #viz.lines == 0 then
+    log.err "ObsidianExtractLink must be called with visual selection"
+    return
+  elseif #viz.lines ~= 1 then
+    log.err "Only in-line visual selections allowed"
+    return
+  end
+
+  local content
+  if string.len(data.args) > 0 then
+    content = { data.args }
+  else
+    content = viz.lines
+  end
+
+  -- new note with title from user
+  local title = vim.fn.input { prompt = "Enter title (optional): " }
+  if string.len(title) == 0 then
+    title = nil
+  end
+  local note = client:new_note(title, nil, client.buf_dir)
+
+  -- replace selection with link to new note
+  local link = client:format_link(note, {})
+  vim.api.nvim_buf_set_lines(0, viz.csrow - 1, viz.cerow + 1, false, { link })
+
+  -- add the selected text to the end of the new note
+  local open_in = util.get_open_strategy(client.opts.open_notes_in)
+  vim.cmd(open_in .. tostring(note.path))
+  vim.api.nvim_buf_set_lines(0, -1, -1, false, content)
+end

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -21,6 +21,7 @@ local command_lookups = {
   ObsidianWorkspace = "obsidian.commands.workspace",
   ObsidianRename = "obsidian.commands.rename",
   ObsidianPasteImg = "obsidian.commands.paste_img",
+  ObsidianExtractNote = "obsidian.commands.extract_note",
 }
 
 local M = setmetatable({
@@ -184,6 +185,11 @@ M.register(
 M.register(
   "ObsidianPasteImg",
   { opts = { nargs = "?", complete = "file", desc = "Paste and image from the clipboard" } }
+)
+
+M.register(
+  "ObsidianExtractNote",
+  { opts = { nargs = "?", range = true, desc = "Extract selected text to a new note and link to it" } }
 )
 
 return M


### PR DESCRIPTION
Here is a draft of the feature described in #382. The feature behaves like in the issue.

A few comments:

- Pretty straight forward implementation.
- I added the `open_in` feature
- I reverted from `vim.ui.input` to using `vim.input` as this is used throughout `obsidian.nvim`. (Maybe in the future one could take a look at [`vim.ui.select`](https://github.com/neovim/neovim/pull/15771) and [`vim.ui.input`](https://github.com/neovim/neovim/pull/15959) to automatically get nicer and user specific selectors and input forms. Also see [dressing](https://github.com/stevearc/dressing.nvim).)

I think there is one problem with the `get_visual_selection()` helper. Once you had a visual selection you get that selection even if you have not selected anything. This basically makes the check at the beginning of the function useless (or they only kick in with a fresh nvim instance that has not selected anything yet).
This is a problem for all functions/commands that use the `get_visual_selection()` helper.
I did not try to fix this. I stuck to the implementation very much like the other commands. Bus at some point, this should probably addressed.

Let me know if you have any feedback. Thanks.