### PR TITLE
Added support for file links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for `file:/` and `file:///` Urls.
+
+### Fixed
+
+- Urls ending in `/` were not detected
+
 ## [v3.2.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.2.0) - 2024-02-13
 
 ### Added

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -627,9 +627,9 @@ end
 Client.resolve_link_async = function(self, link, callback)
   local location, name, link_type
   if link then
-    location, name, link_type = util.parse_link(link, { include_naked_urls = true })
+    location, name, link_type = util.parse_link(link, { include_naked_urls = true, include_file_urls = true })
   else
-    location, name, link_type = util.parse_cursor_link { include_naked_urls = true }
+    location, name, link_type = util.parse_cursor_link { include_naked_urls = true, include_file_urls = true }
   end
 
   if location == nil or name == nil or link_type == nil then

--- a/lua/obsidian/commands/backlinks.lua
+++ b/lua/obsidian/commands/backlinks.lua
@@ -7,7 +7,7 @@ return function(client, _)
   ---@type obsidian.Note|?
   local note
   local cursor_link, _, ref_type = util.parse_cursor_link()
-  if cursor_link ~= nil and ref_type ~= RefTypes.NakedUrl then
+  if cursor_link ~= nil and ref_type ~= RefTypes.NakedUrl and ref_type ~= RefTypes.FileUrl then
     note = client:resolve_note(cursor_link)
     if note == nil then
       log.err "Could not resolve link under cursor to a note ID, path, or alias"

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -20,7 +20,7 @@ return function(client, data)
     end
   else
     local cursor_link, _, ref_type = util.parse_cursor_link()
-    if cursor_link ~= nil and ref_type ~= RefTypes.NakedUrl then
+    if cursor_link ~= nil and ref_type ~= RefTypes.NakedUrl and ref_type ~= RefTypes.FileUrl then
       local note = client:resolve_note(cursor_link)
       if note ~= nil then
         path = assert(client:vault_relative_path(note.path))

--- a/lua/obsidian/search.lua
+++ b/lua/obsidian/search.lua
@@ -18,6 +18,7 @@ M.RefTypes = {
   Wiki = "Wiki",
   Markdown = "Markdown",
   NakedUrl = "NakedUrl",
+  FileUrl = "FileUrl",
   Tag = "Tag",
 }
 
@@ -35,7 +36,8 @@ M.Patterns = {
   WikiWithAlias = "%[%[[^][%|]+%|[^%]]+%]%]", -- [[xxx|yyy]]
   Wiki = "%[%[[^][%|]+%]%]", -- [[xxx]]
   Markdown = "%[[^][]+%]%([^%)]+%)", -- [yyy](xxx)
-  NakedUrl = "https?://[a-zA-Z0-9._-]+[a-zA-Z0-9._#/=&?:%%-]+[a-zA-Z0-9]", -- https://xyz.com
+  NakedUrl = "https?://[a-zA-Z0-9._-]+[a-zA-Z0-9._#/=&?:%%-]+[a-zA-Z0-9/]", -- https://xyz.com
+  FileUrl = "file:/[/{2}]?.*", -- file:///
 }
 
 --- Find all matches of a pattern
@@ -120,6 +122,7 @@ end
 ---
 ---@field include_naked_urls boolean|?
 ---@field include_tags boolean|?
+---@field include_file_urls boolean|?
 
 --- Find refs and URLs.
 ---@param s string the string to search
@@ -135,6 +138,9 @@ M.find_refs = function(s, opts)
   end
   if opts.include_tags then
     pattern_names[#pattern_names + 1] = M.RefTypes.Tag
+  end
+  if opts.include_file_urls then
+    pattern_names[#pattern_names + 1] = M.RefTypes.FileUrl
   end
 
   return M.find_matches(s, pattern_names)

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -161,8 +161,10 @@ end
 util.is_url = function(s)
   local search = require "obsidian.search"
 
-  if string.match(util.strip_whitespace(s), "^" .. search.Patterns[search.RefTypes.NakedUrl] .. "$") or
-     string.match(util.strip_whitespace(s), "^" .. search.Patterns[search.RefTypes.FileUrl] .. "$") then
+  if
+    string.match(util.strip_whitespace(s), "^" .. search.Patterns[search.RefTypes.NakedUrl] .. "$")
+    or string.match(util.strip_whitespace(s), "^" .. search.Patterns[search.RefTypes.FileUrl] .. "$")
+  then
     return true
   else
     return false
@@ -593,7 +595,11 @@ util.cursor_on_markdown_link = function(line, col, include_naked_urls, include_f
   local _, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
   cur_col = col or cur_col + 1 -- nvim_win_get_cursor returns 0-indexed column
 
-  for match in iter(search.find_refs(current_line, { include_naked_urls = include_naked_urls, include_file_urls = include_file_urls })) do
+  for match in
+    iter(
+      search.find_refs(current_line, { include_naked_urls = include_naked_urls, include_file_urls = include_file_urls })
+    )
+  do
     local open, close, m_type = unpack(match)
     if open <= cur_col and cur_col <= close then
       return open, close, m_type
@@ -612,7 +618,12 @@ end
 ---
 ---@return string|?, string|?, obsidian.search.RefTypes|?
 util.cursor_link = function(line, col, include_naked_urls, include_file_urls)
-  return util.parse_cursor_link { line = line, col = col, include_naked_urls = include_naked_urls, include_file_urls = include_file_urls }
+  return util.parse_cursor_link {
+    line = line,
+    col = col,
+    include_naked_urls = include_naked_urls,
+    include_file_urls = include_file_urls,
+  }
 end
 
 --- Get the link location and name of the link under the cursor, if there is one.
@@ -624,7 +635,8 @@ util.parse_cursor_link = function(opts)
   opts = opts and opts or {}
 
   local current_line = opts.line and opts.line or vim.api.nvim_get_current_line()
-  local open, close, link_type = util.cursor_on_markdown_link(current_line, opts.col, opts.include_naked_urls, opts.include_file_urls)
+  local open, close, link_type =
+    util.cursor_on_markdown_link(current_line, opts.col, opts.include_naked_urls, opts.include_file_urls)
   if open == nil or close == nil then
     return
   end
@@ -644,7 +656,14 @@ util.parse_link = function(link, opts)
 
   local link_type = opts.link_type
   if link_type == nil then
-    for match in iter(search.find_refs(link, { include_naked_urls = opts.include_naked_urls, include_file_urls = opts.include_file_urls })) do
+    for match in
+      iter(
+        search.find_refs(
+          link,
+          { include_naked_urls = opts.include_naked_urls, include_file_urls = opts.include_file_urls }
+        )
+      )
+    do
       local _, _, m_type = unpack(match)
       if m_type then
         link_type = m_type

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -161,7 +161,8 @@ end
 util.is_url = function(s)
   local search = require "obsidian.search"
 
-  if string.match(util.strip_whitespace(s), "^" .. search.Patterns[search.RefTypes.NakedUrl] .. "$") then
+  if string.match(util.strip_whitespace(s), "^" .. search.Patterns[search.RefTypes.NakedUrl] .. "$") or
+     string.match(util.strip_whitespace(s), "^" .. search.Patterns[search.RefTypes.FileUrl] .. "$") then
     return true
   else
     return false
@@ -583,15 +584,16 @@ end
 ---@param line string|nil - line to check or current line if nil
 ---@param col  integer|nil - column to check or current column if nil (1-indexed)
 ---@param include_naked_urls boolean|?
+---@param include_file_urls boolean|?
 ---@return integer|nil, integer|nil, obsidian.search.RefTypes|? - start and end column of link (1-indexed)
-util.cursor_on_markdown_link = function(line, col, include_naked_urls)
+util.cursor_on_markdown_link = function(line, col, include_naked_urls, include_file_urls)
   local search = require "obsidian.search"
 
   local current_line = line and line or vim.api.nvim_get_current_line()
   local _, cur_col = unpack(vim.api.nvim_win_get_cursor(0))
   cur_col = col or cur_col + 1 -- nvim_win_get_cursor returns 0-indexed column
 
-  for match in iter(search.find_refs(current_line, { include_naked_urls = include_naked_urls })) do
+  for match in iter(search.find_refs(current_line, { include_naked_urls = include_naked_urls, include_file_urls = include_file_urls })) do
     local open, close, m_type = unpack(match)
     if open <= cur_col and cur_col <= close then
       return open, close, m_type
@@ -606,10 +608,11 @@ end
 ---@param line string|?
 ---@param col integer|?
 ---@param include_naked_urls boolean|?
+---@param include_file_urls boolean|?
 ---
 ---@return string|?, string|?, obsidian.search.RefTypes|?
-util.cursor_link = function(line, col, include_naked_urls)
-  return util.parse_cursor_link { line = line, col = col, include_naked_urls = include_naked_urls }
+util.cursor_link = function(line, col, include_naked_urls, include_file_urls)
+  return util.parse_cursor_link { line = line, col = col, include_naked_urls = include_naked_urls, include_file_urls = include_file_urls }
 end
 
 --- Get the link location and name of the link under the cursor, if there is one.
@@ -621,7 +624,7 @@ util.parse_cursor_link = function(opts)
   opts = opts and opts or {}
 
   local current_line = opts.line and opts.line or vim.api.nvim_get_current_line()
-  local open, close, link_type = util.cursor_on_markdown_link(current_line, opts.col, opts.include_naked_urls)
+  local open, close, link_type = util.cursor_on_markdown_link(current_line, opts.col, opts.include_naked_urls, opts.include_file_urls)
   if open == nil or close == nil then
     return
   end
@@ -631,7 +634,7 @@ util.parse_cursor_link = function(opts)
 end
 
 ---@param link string
----@param opts { include_naked_urls: boolean|?, link_type: obsidian.search.RefTypes|? }|?
+---@param opts { include_naked_urls: boolean|?, include_file_urls: boolean|?, link_type: obsidian.search.RefTypes|? }|?
 ---
 ---@return string|?, string|?, obsidian.search.RefTypes|?
 util.parse_link = function(link, opts)
@@ -641,7 +644,7 @@ util.parse_link = function(link, opts)
 
   local link_type = opts.link_type
   if link_type == nil then
-    for match in iter(search.find_refs(link, { include_naked_urls = opts.include_naked_urls })) do
+    for match in iter(search.find_refs(link, { include_naked_urls = opts.include_naked_urls, include_file_urls = opts.include_file_urls })) do
       local _, _, m_type = unpack(match)
       if m_type then
         link_type = m_type
@@ -659,6 +662,9 @@ util.parse_link = function(link, opts)
     link_location = link:gsub("^%[(.-)%]%((.*)%)$", "%2")
     link_name = link:gsub("^%[(.-)%]%((.*)%)$", "%1")
   elseif link_type == search.RefTypes.NakedUrl then
+    link_location = link
+    link_name = link
+  elseif link_type == search.RefTypes.FileUrl then
     link_location = link
     link_name = link
   elseif link_type == search.RefTypes.WikiWithAlias then


### PR DESCRIPTION
This pull request fixes a small bug when `http` Urls ended in `/` (they were not detected), and also adds support for `file:/` and `file:///` links, detecting them and enabling the user to follow them.

This PR adds support for feature [#356](https://github.com/epwalsh/obsidian.nvim/issues/356)