### PR TITLE
Add customization of wiki/markdown link format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for `file:/` and `file:///` Urls.
+- Added configuration options `wiki_link_func` and `markdown_link_func` for customizing how links are formatted.
 
 ### Fixed
 
 - Urls ending in `/` were not detected.
 - Fixed small bug with toggle checkbox mapping where lines that started with a wiki link or md link were misclassified.
+
+### Changed
+
+- Config options `completion.prepend_note_id`, `completion.prepend_note_path`, and `completion.use_path_only` are now deprecated. Please use `wiki_link_func` and `markdown_link_func` instead.
 
 ## [v3.2.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.2.0) - 2024-02-13
 

--- a/README.md
+++ b/README.md
@@ -268,21 +268,6 @@ This is a complete list of all of the options that can be passed to `require("ob
 
     -- Either 'wiki' or 'markdown'.
     preferred_link_style = "wiki",
-
-    -- Control how wiki links are completed with these (mutually exclusive) options:
-    --
-    -- 1. Whether to add the note ID during completion.
-    -- E.g. "[[Foo" completes to "[[foo|Foo]]" assuming "foo" is the ID of the note.
-    -- Mutually exclusive with 'prepend_note_path' and 'use_path_only'.
-    prepend_note_id = true,
-    -- 2. Whether to add the note path during completion.
-    -- E.g. "[[Foo" completes to "[[notes/foo|Foo]]" assuming "notes/foo.md" is the path of the note.
-    -- Mutually exclusive with 'prepend_note_id' and 'use_path_only'.
-    prepend_note_path = false,
-    -- 3. Whether to only use paths during completion.
-    -- E.g. "[[Foo" completes to "[[notes/foo]]" assuming "notes/foo.md" is the path of the note.
-    -- Mutually exclusive with 'prepend_note_id' and 'prepend_note_path'.
-    use_path_only = false,
   },
 
   -- Optional, configure key mappings. These are the defaults. If you don't want to set any keymappings this
@@ -322,7 +307,28 @@ This is a complete list of all of the options that can be passed to `require("ob
     return tostring(os.time()) .. "-" .. suffix
   end,
 
+  -- Optional, customize how wiki links are formatted.
+  ---@param opts {path: string, label: string, id: string|?}
+  ---@return string
+  wiki_link_func = function(opts)
+    if opts.id == nil then
+      return string.format("[[%s]]", opts.label)
+    elseif opts.label ~= opts.id then
+      return string.format("[[%s|%s]]", opts.id, opts.label)
+    else
+      return string.format("[[%s]]", opts.id)
+    end
+  end,
+
+  -- Optional, customize how markdown links are formatted.
+  ---@param opts {path: string, label: string, id: string|?}
+  ---@return string
+  markdown_link_func = function(opts)
+    return string.format("[%s](%s)", opts.label, opts.path)
+  end,
+
   -- Optional, customize the default name or prefix when pasting images via `:ObsidianPasteImg`.
+  ---@return string
   image_name_func = function()
     -- Prefix image names with timestamp.
     return string.format("%s-", os.time())
@@ -333,6 +339,7 @@ This is a complete list of all of the options that can be passed to `require("ob
   disable_frontmatter = false,
 
   -- Optional, alternatively you can customize the frontmatter data.
+  ---@return table
   note_frontmatter_func = function(note)
     -- Add the title of the note as an alias.
     if note.title then
@@ -379,6 +386,7 @@ This is a complete list of all of the options that can be passed to `require("ob
 
   -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
   -- URL it will be ignored but you can customize this behavior here.
+  ---@param url
   follow_url_func = function(url)
     -- Open the URL in the default web browser.
     vim.fn.jobstart({"open", url})  -- Mac OS

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ This is a complete list of all of the options that can be passed to `require("ob
 
   -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
   -- URL it will be ignored but you can customize this behavior here.
-  ---@param url
+  ---@param url string
   follow_url_func = function(url)
     -- Open the URL in the default web browser.
     vim.fn.jobstart({"open", url})  -- Mac OS

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1328,40 +1328,15 @@ Client.format_link = function(self, note, opts)
     note_id = tostring(note.id)
   end
 
-  if vim.endswith(rel_path, ".md") then
-    rel_path = string.sub(rel_path, 1, -4)
-  end
+  local new_opts = { path = rel_path, label = label, id = note_id }
 
-  ---@type string
-  local link
   if opts.link_style == config.LinkStyle.markdown then
-    link = "[" .. label .. "](" .. rel_path .. ".md)"
+    return self.opts.markdown_link_func(new_opts)
   elseif opts.link_style == config.LinkStyle.wiki or opts.link_style == nil then
-    if self.opts.completion.use_path_only then
-      link = "[[" .. rel_path .. "]]"
-    elseif self.opts.completion.prepend_note_path then
-      link = "[[" .. rel_path
-      if label ~= note_id then
-        link = link .. "|" .. label .. "]]"
-      else
-        link = link .. "]]"
-      end
-    elseif self.opts.completion.prepend_note_id then
-      assert(note_id, "missing 'id' field in 'format_link()' options")
-      link = "[[" .. note_id
-      if label ~= note_id then
-        link = link .. "|" .. label .. "]]"
-      else
-        link = link .. "]]"
-      end
-    else
-      link = "[[" .. label .. "]]"
-    end
+    return self.opts.wiki_link_func(new_opts)
   else
     error(string.format("Invalid link style '%s'", opts.link_style))
   end
-
-  return link
 end
 
 --- Get the default Picker.

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -148,7 +148,8 @@ config.ClientOpts.normalize = function(opts, defaults)
   then
     log.warn_once(
       "The config options 'completion.prepend_note_id', 'completion.prepend_note_path', and 'completion.use_path_only' "
-        .. "are deprecated. Please use 'wiki_link_func' instead."
+        .. "are deprecated. Please use 'wiki_link_func' instead.\n"
+        .. "See https://github.com/epwalsh/obsidian.nvim/pull/406"
     )
   end
 

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -10,6 +10,8 @@ local config = {}
 ---@field notes_subdir string|?
 ---@field templates obsidian.config.TemplateOpts
 ---@field note_id_func (fun(title: string|?): string)|?
+---@field wiki_link_func (fun(opts: {path: string, label: string, id: string|?}): string)
+---@field markdown_link_func (fun(opts: {path: string, label: string, id: string|?}): string)
 ---@field follow_url_func fun(url: string)|?
 ---@field image_name_func (fun(): string)|?
 ---@field note_frontmatter_func fun(note: obsidian.Note)|?
@@ -41,6 +43,8 @@ config.ClientOpts.default = function()
     notes_subdir = nil,
     templates = config.TemplateOpts.default(),
     note_id_func = nil,
+    wiki_link_func = util.wiki_link_id_prefix,
+    markdown_link_func = util.markdown_link,
     follow_url_func = nil,
     note_frontmatter_func = nil,
     disable_frontmatter = false,
@@ -99,6 +103,16 @@ config.ClientOpts.normalize = function(opts, defaults)
     end
   end
 
+  if opts.wiki_link_func == nil and opts.completion ~= nil then
+    if opts.completion.prepend_note_id then
+      opts.wiki_link_func = util.wiki_link_id_prefix
+    elseif opts.completion.prepend_note_path then
+      opts.wiki_link_func = util.wiki_link_path_prefix
+    elseif opts.completion.use_path_only then
+      opts.wiki_link_func = util.wiki_link_path_only
+    end
+  end
+
   ---@type obsidian.config.ClientOpts
   opts = tbl_override(defaults, opts)
 
@@ -116,23 +130,26 @@ config.ClientOpts.normalize = function(opts, defaults)
     error("Invalid 'sort_by' option '" .. opts.sort_by .. "' in obsidian.nvim config.")
   end
 
-  if
-    not opts.completion.prepend_note_id
-    and not opts.completion.prepend_note_path
-    and not opts.completion.use_path_only
-  then
-    error(
-      "Invalid 'completion' options in obsidian.nvim config.\n"
-        .. "One of 'prepend_note_id', 'prepend_note_path', or 'use_path_only' should be set to 'true'."
-    )
-  end
-
   -- Warn about deprecated fields.
   ---@diagnostic disable-next-line undefined-field
   if opts.overwrite_mappings ~= nil then
     log.warn_once "The 'overwrite_mappings' config option is deprecated and no longer has any affect."
     ---@diagnostic disable-next-line
     opts.overwrite_mappings = nil
+  end
+
+  if
+    ---@diagnostic disable-next-line undefined-field
+    opts.completion.prepend_note_id ~= nil
+    ---@diagnostic disable-next-line undefined-field
+    or opts.completion.prepend_note_path ~= nil
+    ---@diagnostic disable-next-line undefined-field
+    or opts.completion.use_path_only ~= nil
+  then
+    log.warn_once(
+      "The config options 'completion.prepend_note_id', 'completion.prepend_note_path', and 'completion.use_path_only' "
+        .. "are deprecated. Please use 'wiki_link_func' instead."
+    )
   end
 
   ---@diagnostic disable-next-line undefined-field
@@ -203,9 +220,6 @@ config.LinkStyle = {
 ---@field nvim_cmp boolean
 ---@field min_chars integer
 ---@field new_notes_location obsidian.config.CompletionNewNotesLocation
----@field prepend_note_id boolean
----@field prepend_note_path boolean
----@field use_path_only boolean
 ---@field preferred_link_style obsidian.config.LinkStyle
 config.CompletionOpts = {}
 
@@ -218,9 +232,6 @@ config.CompletionOpts.default = function()
     nvim_cmp = has_nvim_cmp,
     min_chars = 2,
     new_notes_location = config.CompletionNewNotesLocation.current_dir,
-    prepend_note_id = true,
-    prepend_note_path = false,
-    use_path_only = false,
     preferred_link_style = config.LinkStyle.wiki,
   }
 end

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -922,19 +922,17 @@ end
 ---@param opts {path: string, label: string, id: string|?}
 ---@return string
 util.wiki_link_path_only = function(opts)
-  return "[[" .. opts.path .. "]]"
+  return string.format("[[%s]]", opts.path)
 end
 
 ---@param opts {path: string, label: string, id: string|?}
 ---@return string
 util.wiki_link_path_prefix = function(opts)
-  local link = "[[" .. opts.path
   if opts.label ~= opts.path then
-    link = link .. "|" .. opts.label .. "]]"
+    return string.format("[[%s|%s]]", opts.path, opts.label)
   else
-    link = link .. "]]"
+    return string.format("[[%s]]", opts.path)
   end
-  return link
 end
 
 ---@param opts {path: string, label: string, id: string|?}

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -919,4 +919,40 @@ util.get_visual_selection = function()
   }
 end
 
+---@param opts {path: string, label: string, id: string|?}
+---@return string
+util.wiki_link_path_only = function(opts)
+  return "[[" .. opts.path .. "]]"
+end
+
+---@param opts {path: string, label: string, id: string|?}
+---@return string
+util.wiki_link_path_prefix = function(opts)
+  local link = "[[" .. opts.path
+  if opts.label ~= opts.path then
+    link = link .. "|" .. opts.label .. "]]"
+  else
+    link = link .. "]]"
+  end
+  return link
+end
+
+---@param opts {path: string, label: string, id: string|?}
+---@return string
+util.wiki_link_id_prefix = function(opts)
+  if opts.id == nil then
+    return string.format("[[%s]]", opts.label)
+  elseif opts.label ~= opts.id then
+    return string.format("[[%s|%s]]", opts.id, opts.label)
+  else
+    return string.format("[[%s]]", opts.id)
+  end
+end
+
+---@param opts {path: string, label: string, id: string|?}
+---@return string
+util.markdown_link = function(opts)
+  return string.format("[%s](%s)", opts.label, opts.path)
+end
+
 return util


### PR DESCRIPTION
Via new configuration options `wiki_link_func` and `markdown_link_func`, while deprecating `completion.prepend_note_id`, `completion.prepend_note_path`, and `completion.use_path_only`.

This is backwards-compatible change, though you will see a warning on startup if you continue to use the deprecated config options.

To upgrade your config, set `wiki_link_func` as follows. If you have `completion.prepend_note_id`, then set:

```lua
wiki_link_func = function(opts)
  if opts.id == nil then
    return string.format("[[%s]]", opts.label)
  elseif opts.label ~= opts.id then
    return string.format("[[%s|%s]]", opts.id, opts.label)
  else
    return string.format("[[%s]]", opts.id)
  end
end,
```

If you have `completion.prepend_note_path`, then set:

```lua
wiki_link_func = function(opts)
  if opts.label ~= opts.path then
    return string.format("[[%s|%s]]", opts.path, opts.label)
  else
    return string.format("[[%s]]", opts.path)
  end
end,
```

Or if you have `completion.use_path_only`, then set:

```lua
wiki_link_func = function(opts)
  return string.format("[[%s]]", opts.path)
end,
```

---

Closes #377, closes #334.