### PR TITLE
Avoid `vim.fs.joinpath` for compat with nvim 0.9.*

### DIFF
--- a/lua/obsidian/path.lua
+++ b/lua/obsidian/path.lua
@@ -255,10 +255,21 @@ end
 ---@return obsidian.Path
 Path.joinpath = function(self, ...)
   local args = { ... }
-  for i, v in ipairs(args) do
-    args[i] = tostring(v)
+  -- `vim.fs.joinpath` was introduced after neovim 0.9.*
+  -- for i, v in ipairs(args) do
+  --   args[i] = tostring(v)
+  -- end
+  -- return Path.new(vim.fs.joinpath(self.filename, unpack(args)))
+  local filename = self.filename
+  for _, v in ipairs(args) do
+    v = vim.fs.normalize(tostring(v))
+    if vim.startswith(v, "/") then
+      filename = filename .. v
+    else
+      filename = filename .. "/" .. v
+    end
   end
-  return Path.new(vim.fs.joinpath(self.filename, unpack(args)))
+  return Path.new(filename)
 end
 
 --- Try to resolve a version of the path relative to the other.

--- a/test/obsidian/path_spec.lua
+++ b/test/obsidian/path_spec.lua
@@ -99,6 +99,8 @@ end)
 describe("Path.joinpath()", function()
   it("can join multiple", function()
     assert.is_true(Path.new "foo/bar/baz.md" == Path.new("foo"):joinpath("bar", "baz.md"))
+    assert.is_true(Path.new "foo/bar/baz.md" == Path.new("foo/"):joinpath("bar/", "baz.md"))
+    assert.is_true(Path.new "foo/bar/baz.md" == Path.new("foo/"):joinpath("bar/", "/baz.md"))
   end)
 end)
 


### PR DESCRIPTION
Closes #301.