### PR TITLE
FreeBSD support for ObsidianOpen

### DIFF
--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -59,7 +59,7 @@ return function(client, data)
 
   ---@type string, string[]
   local cmd, args
-  if this_os == util.OSType.Linux then
+  if this_os == util.OSType.Linux or util.OSType.FreeBSD then
     cmd = "xdg-open"
     args = { uri }
   elseif this_os == util.OSType.Wsl then

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -393,6 +393,7 @@ util.OSType = {
   Wsl = "Wsl",
   Windows = "Windows",
   Darwin = "Darwin",
+  FreeBSD = "FreeBSD",
 }
 
 util._current_os = nil


### PR DESCRIPTION
- Added OSType enum value for FreeBSD.
- Added FreeBSD to existing Linux platform check conditional.