### PR TITLE
fix: os select bug in open command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed os selection in `ObsidianOpen` command.
+
 ## [v3.5.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.5.1) - 2024-02-24
 
 Minor internal improvements.

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -59,7 +59,7 @@ return function(client, data)
 
   ---@type string, string[]
   local cmd, args
-  if this_os == util.OSType.Linux or util.OSType.FreeBSD then
+  if this_os == util.OSType.Linux or this_os == util.OSType.FreeBSD then
     cmd = "xdg-open"
     args = { uri }
   elseif this_os == util.OSType.Wsl then


### PR DESCRIPTION
Hi, there is one very small bug that `obsidian.nvim` always chooses `util.OSType.FreeBSD` whatever your os is.
