### PR TITLE
Picker improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added config option `picker.tag_mappings`, analogous to `picker.note_mappings`.
+
+### Changed
+
+- Renamed config option `picker.mappings` to `picker.note_mappings`.
+
 ## [v3.6.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.6.1) - 2024-02-28
 
 ### Added

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -755,7 +755,7 @@ end
 ---@return obsidian.Note|?
 ---@diagnostic disable-next-line: unused-local
 Client.current_note = function(self)
-  if vim.bo.filetype ~= "markdown" then
+  if vim.bo.filetype ~= "markdown" or not self:path_is_note(vim.api.nvim_buf_get_name(0)) then
     return nil
   end
 
@@ -1450,6 +1450,20 @@ Client.write_note = function(self, note, opts)
   }
 
   log.info("%s note '%s' at '%s'", verb, note.id, self:vault_relative_path(note.path) or note.path)
+end
+
+--- Update the frontmatter in a buffer for the note.
+---
+---@param note obsidian.Note
+---@param bufnr integer|?
+---
+---@return boolean updated If the the frontmatter was updated.
+Client.update_frontmatter = function(self, note, bufnr)
+  local frontmatter = nil
+  if self.opts.note_frontmatter_func ~= nil then
+    frontmatter = self.opts.note_frontmatter_func(note)
+  end
+  return note:save_to_buffer(bufnr, frontmatter)
 end
 
 --- Get the path to a daily note.

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -750,16 +750,19 @@ Client.open_note = function(self, note_or_path, opts)
   util.open_buffer(path, { line = opts.line, col = opts.col, cmd = open_cmd })
 end
 
---- Get the current note.
+--- Get the current note from a buffer.
+---
+---@param bufnr integer|?
 ---
 ---@return obsidian.Note|?
 ---@diagnostic disable-next-line: unused-local
-Client.current_note = function(self)
-  if vim.bo.filetype ~= "markdown" or not self:path_is_note(vim.api.nvim_buf_get_name(0)) then
+Client.current_note = function(self, bufnr)
+  bufnr = bufnr or 0
+  if not self:path_is_note(vim.api.nvim_buf_get_name(bufnr)) then
     return nil
   end
 
-  return Note.from_buffer(0)
+  return Note.from_buffer(bufnr)
 end
 
 ---@class obsidian.TagLocation

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -117,6 +117,11 @@ Client.set_workspace = function(self, workspace, opts)
     daily_notes_subdir:mkdir { parents = true, exists_ok = true }
   end
 
+  -- Setup UI add-ons.
+  if self.opts.ui.enable then
+    require("obsidian.ui").setup(self.current_workspace, self.opts.ui)
+  end
+
   if opts.lock then
     self.current_workspace:lock()
   end

--- a/lua/obsidian/commands/link.lua
+++ b/lua/obsidian/commands/link.lua
@@ -45,7 +45,7 @@ return function(client, data)
     return
   end
 
-  picker:grep {
+  picker:grep_notes {
     prompt_title = "Link note",
     query = search_term,
     no_default_mappings = true,

--- a/lua/obsidian/commands/quick_switch.lua
+++ b/lua/obsidian/commands/quick_switch.lua
@@ -8,5 +8,5 @@ return function(client, _)
     return
   end
 
-  picker:find_notes { prompt_title = "Notes" }
+  picker:find_notes()
 end

--- a/lua/obsidian/commands/search.lua
+++ b/lua/obsidian/commands/search.lua
@@ -7,5 +7,5 @@ return function(client, data)
     log.err "No picker configured"
     return
   end
-  picker:grep { prompt_title = "Grep notes", query = data.args }
+  picker:grep_notes { query = data.args }
 end

--- a/lua/obsidian/commands/tags.lua
+++ b/lua/obsidian/commands/tags.lua
@@ -92,8 +92,7 @@ return function(client, data)
     client:list_tags_async(nil, function(all_tags)
       vim.schedule(function()
         -- Open picker with tags.
-        picker:pick(all_tags, {
-          prompt_title = "Tags",
+        picker:pick_tag(all_tags, {
           callback = function(tag)
             gather_tag_picker_list(client, picker, { tag })
           end,

--- a/lua/obsidian/commands/tags.lua
+++ b/lua/obsidian/commands/tags.lua
@@ -93,9 +93,10 @@ return function(client, data)
       vim.schedule(function()
         -- Open picker with tags.
         picker:pick_tag(all_tags, {
-          callback = function(tag)
-            gather_tag_picker_list(client, picker, { tag })
+          callback = function(...)
+            gather_tag_picker_list(client, picker, { ... })
           end,
+          allow_multiple = true,
         })
       end)
     end)

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -100,8 +100,12 @@ config.ClientOpts.normalize = function(opts, defaults)
       opts.finder = nil
     end
     if opts.finder_mappings then
-      opts.picker.mappings = opts.finder_mappings
+      opts.picker.note_mappings = opts.finder_mappings
       opts.finder_mappings = nil
+    end
+    if opts.picker.mappings and not opts.picker.note_mappings then
+      opts.picker.note_mappings = opts.picker.mappings
+      opts.picker.mappings = nil
     end
   end
 
@@ -265,18 +269,32 @@ config.MappingOpts.default = function()
   }
 end
 
----@class obsidian.config.PickerMappingOpts
+---@class obsidian.config.PickerNoteMappingOpts
 ---
 ---@field new string|?
 ---@field insert_link string|?
-config.PickerMappingOpts = {}
+config.PickerNoteMappingOpts = {}
 
 ---Get defaults.
----@return obsidian.config.PickerMappingOpts
-config.PickerMappingOpts.default = function()
+---@return obsidian.config.PickerNoteMappingOpts
+config.PickerNoteMappingOpts.default = function()
   return {
     new = "<C-x>",
     insert_link = "<C-l>",
+  }
+end
+
+---@class obsidian.config.PickerTagMappingOpts
+---
+---@field tag_note string|?
+---@field insert_tag string|?
+config.PickerTagMappingOpts = {}
+
+---@return obsidian.config.PickerTagMappingOpts
+config.PickerTagMappingOpts.default = function()
+  return {
+    tag_note = "<C-x>",
+    insert_tag = "<C-l>",
   }
 end
 
@@ -290,7 +308,8 @@ config.Picker = {
 ---@class obsidian.config.PickerOpts
 ---
 ---@field name obsidian.config.Picker|?
----@field mappings obsidian.config.PickerMappingOpts
+---@field note_mappings obsidian.config.PickerNoteMappingOpts
+---@field tag_mappings obsidian.config.PickerTagMappingOpts
 config.PickerOpts = {}
 
 --- Get the defaults.
@@ -299,7 +318,8 @@ config.PickerOpts = {}
 config.PickerOpts.default = function()
   return {
     name = nil,
-    mappings = config.PickerMappingOpts.default(),
+    note_mappings = config.PickerNoteMappingOpts.default(),
+    tag_mappings = config.PickerTagMappingOpts.default(),
   }
 end
 

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -107,11 +107,6 @@ obsidian.setup = function(opts)
     cmp.register_source("obsidian_tags", require("cmp_obsidian_tags").new())
   end
 
-  -- Setup UI add-ons.
-  if client.opts.ui.enable then
-    obsidian.ui.setup(client.opts.ui)
-  end
-
   local group = vim.api.nvim_create_augroup("obsidian_setup", { clear = true })
 
   -- Complete setup and update workspace (if needed) when entering a markdown buffer.
@@ -135,6 +130,7 @@ obsidian.setup = function(opts)
       if not client.current_workspace.locked and workspace ~= client.current_workspace then
         log.debug("Switching to workspace '%s' @ '%s'", workspace.name, workspace.path)
         client:set_workspace(workspace)
+        client:update_ui(ev.buf)
       end
 
       -- Register mappings.

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -185,13 +185,7 @@ obsidian.setup = function(opts)
         return
       end
 
-      local frontmatter = nil
-      if client.opts.note_frontmatter_func ~= nil then
-        frontmatter = client.opts.note_frontmatter_func(note)
-      end
-
-      local updated = note:save_to_buffer(bufnr, frontmatter)
-      if not client._quiet and updated then
+      if client:update_frontmatter(note, bufnr) then
         log.info "Updated frontmatter"
       end
     end,

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -130,18 +130,28 @@ end
 --- Add an alias to the note.
 ---
 ---@param alias string
+---
+---@return boolean added True if the alias was added, false if it was already present.
 Note.add_alias = function(self, alias)
   if not self:has_alias(alias) then
     table.insert(self.aliases, alias)
+    return true
+  else
+    return false
   end
 end
 
 --- Add a tag to the note.
 ---
 ---@param tag string
+---
+---@return boolean added True if the tag was added, false if it was already present.
 Note.add_tag = function(self, tag)
   if not self:has_tag(tag) then
     table.insert(self.tags, tag)
+    return true
+  else
+    return false
   end
 end
 

--- a/lua/obsidian/pickers/_fzf.lua
+++ b/lua/obsidian/pickers/_fzf.lua
@@ -139,6 +139,8 @@ end
 ---@param opts obsidian.PickerPickOpts|? Options.
 ---@diagnostic disable-next-line: unused-local
 FzfPicker.pick = function(self, values, opts)
+  self.calling_bufnr = vim.api.nvim_get_current_buf()
+
   opts = opts or {}
 
   ---@type table<string, any>

--- a/lua/obsidian/pickers/_mini.lua
+++ b/lua/obsidian/pickers/_mini.lua
@@ -19,9 +19,9 @@ local MiniPicker = abc.new_class({
   end,
 }, Picker)
 
----@param opts { prompt_title: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|?, dir: string|obsidian.Path|? }|?
+---@param opts obsidian.PickerFindOpts|? Options.
 MiniPicker.find_files = function(self, opts)
-  opts = opts and opts or {}
+  opts = opts or {}
 
   ---@type obsidian.Path
   local dir = opts.dir and Path:new(opts.dir) or self.client.dir
@@ -45,7 +45,7 @@ MiniPicker.find_files = function(self, opts)
   end
 end
 
----@param opts { prompt_title: string|?, dir: string|obsidian.Path|?, query: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|? }|?
+---@param opts obsidian.PickerGrepOpts|? Options.
 MiniPicker.grep = function(self, opts)
   opts = opts and opts or {}
 
@@ -79,7 +79,7 @@ MiniPicker.grep = function(self, opts)
 end
 
 ---@param values string[]|obsidian.PickerEntry[]
----@param opts { prompt_title: string|?, callback: fun(value: any)|? }|?
+---@param opts obsidian.PickerPickOpts|? Options.
 ---@diagnostic disable-next-line: unused-local
 MiniPicker.pick = function(self, values, opts)
   opts = opts and opts or {}

--- a/lua/obsidian/pickers/_mini.lua
+++ b/lua/obsidian/pickers/_mini.lua
@@ -82,6 +82,8 @@ end
 ---@param opts obsidian.PickerPickOpts|? Options.
 ---@diagnostic disable-next-line: unused-local
 MiniPicker.pick = function(self, values, opts)
+  self.calling_bufnr = vim.api.nvim_get_current_buf()
+
   opts = opts and opts or {}
 
   local entries = {}

--- a/lua/obsidian/pickers/_telescope.lua
+++ b/lua/obsidian/pickers/_telescope.lua
@@ -5,6 +5,7 @@ local actions_state = require "telescope.actions.state"
 local Path = require "obsidian.path"
 local abc = require "obsidian.abc"
 local Picker = require "obsidian.pickers.picker"
+local log = require "obsidian.log"
 
 ---@class obsidian.pickers.TelescopePicker : obsidian.Picker
 local TelescopePicker = abc.new_class({
@@ -27,6 +28,33 @@ end
 
 ---@param prompt_bufnr integer
 ---@param keep_open boolean|?
+---@param allow_multiple boolean|?
+---@return table[]|?
+local function get_selected(prompt_bufnr, keep_open, allow_multiple)
+  local picker = actions_state.get_current_picker(prompt_bufnr)
+  local entries = picker:get_multi_selection()
+  if entries and #entries > 0 then
+    if #entries > 1 and not allow_multiple then
+      log.err "This mapping does not allow multiple entries"
+      return
+    end
+
+    if not keep_open then
+      telescope_actions.close(prompt_bufnr)
+    end
+
+    return entries
+  else
+    local entry = get_entry(prompt_bufnr, keep_open)
+
+    if entry then
+      return { entry }
+    end
+  end
+end
+
+---@param prompt_bufnr integer
+---@param keep_open boolean|?
 ---@param initial_query string|?
 ---@return string|?
 local function get_query(prompt_bufnr, keep_open, initial_query)
@@ -44,11 +72,18 @@ local function get_query(prompt_bufnr, keep_open, initial_query)
   end
 end
 
----@param map table
----@param opts { callback: fun(path: string)|?, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|?, initial_query: string|? }
-local function attach_path_picker_mappings(map, opts)
+---@param opts { entry_key: string|?, callback: fun(path: string)|?, allow_multiple: boolean|?, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|?, initial_query: string|? }
+local function attach_picker_mappings(map, opts)
   -- Docs for telescope actions:
   -- https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/actions/init.lua
+
+  local function entry_to_value(entry)
+    if opts.entry_key then
+      return entry[opts.entry_key]
+    else
+      return entry
+    end
+  end
 
   if opts.query_mappings then
     for key, mapping in pairs(opts.query_mappings) do
@@ -64,44 +99,10 @@ local function attach_path_picker_mappings(map, opts)
   if opts.selection_mappings then
     for key, mapping in pairs(opts.selection_mappings) do
       map({ "i", "n" }, key, function(prompt_bufnr)
-        local entry = get_entry(prompt_bufnr)
-        if entry then
-          mapping.callback(entry.path)
-        end
-      end)
-    end
-  end
-
-  if opts.callback then
-    map({ "i", "n" }, "<CR>", function(prompt_bufnr)
-      local entry = get_entry(prompt_bufnr)
-      if entry then
-        opts.callback(entry.path)
-      end
-    end)
-  end
-end
-
----@param map table
----@param opts { callback: fun(item: any)|?, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|? }
-local function attach_value_picker_mappings(map, opts)
-  if opts.query_mappings then
-    for key, mapping in pairs(opts.query_mappings) do
-      map({ "i", "n" }, key, function(prompt_bufnr)
-        local query = get_query(prompt_bufnr)
-        if query then
-          mapping.callback(query)
-        end
-      end)
-    end
-  end
-
-  if opts.selection_mappings then
-    for key, mapping in pairs(opts.selection_mappings) do
-      map({ "i", "n" }, key, function(prompt_bufnr)
-        local entry = get_entry(prompt_bufnr, mapping.keep_open)
-        if entry then
-          mapping.callback(entry.value)
+        local entries = get_selected(prompt_bufnr, mapping.keep_open, mapping.allow_multiple)
+        if entries then
+          local values = vim.tbl_map(entry_to_value, entries)
+          mapping.callback(unpack(values))
         elseif mapping.fallback_to_query then
           local query = get_query(prompt_bufnr, mapping.keep_open)
           if query then
@@ -114,9 +115,10 @@ local function attach_value_picker_mappings(map, opts)
 
   if opts.callback then
     map({ "i", "n" }, "<CR>", function(prompt_bufnr)
-      local entry = get_entry(prompt_bufnr)
-      if entry then
-        opts.callback(entry.value)
+      local entries = get_selected(prompt_bufnr, false, opts.allow_multiple)
+      if entries then
+        local values = vim.tbl_map(entry_to_value, entries)
+        opts.callback(unpack(values))
       end
     end)
   end
@@ -137,10 +139,12 @@ TelescopePicker.find_files = function(self, opts)
     cwd = opts.dir and tostring(opts.dir) or tostring(self.client.dir),
     find_command = self:_build_find_cmd(),
     attach_mappings = function(_, map)
-      attach_path_picker_mappings(
-        map,
-        { callback = opts.callback, query_mappings = opts.query_mappings, selection_mappings = opts.selection_mappings }
-      )
+      attach_picker_mappings(map, {
+        entry_key = "path",
+        callback = opts.callback,
+        query_mappings = opts.query_mappings,
+        selection_mappings = opts.selection_mappings,
+      })
       return true
     end,
   }
@@ -159,7 +163,8 @@ TelescopePicker.grep = function(self, opts)
   }
 
   local attach_mappings = function(_, map)
-    attach_path_picker_mappings(map, {
+    attach_picker_mappings(map, {
+      entry_key = "path",
       callback = opts.callback,
       query_mappings = opts.query_mappings,
       selection_mappings = opts.selection_mappings,
@@ -200,10 +205,13 @@ TelescopePicker.pick = function(self, values, opts)
 
   local picker_opts = {
     attach_mappings = function(_, map)
-      attach_value_picker_mappings(
-        map,
-        { callback = opts.callback, query_mappings = opts.query_mappings, selection_mappings = opts.selection_mappings }
-      )
+      attach_picker_mappings(map, {
+        entry_key = "value",
+        callback = opts.callback,
+        allow_multiple = opts.allow_multiple,
+        query_mappings = opts.query_mappings,
+        selection_mappings = opts.selection_mappings,
+      })
       return true
     end,
   }

--- a/lua/obsidian/pickers/_telescope.lua
+++ b/lua/obsidian/pickers/_telescope.lua
@@ -1,4 +1,6 @@
 local telescope = require "telescope.builtin"
+local telescope_actions = require "telescope.actions"
+local actions_state = require "telescope.actions.state"
 
 local Path = require "obsidian.path"
 local abc = require "obsidian.abc"
@@ -12,112 +14,157 @@ local TelescopePicker = abc.new_class({
   end,
 }, Picker)
 
----@param opts { prompt_title: string|?, no_default_mappings: boolean|?, dir: string|obsidian.Path|? }
----
----@return string
-TelescopePicker.prompt_title = function(self, opts)
-  local name = opts.prompt_title and opts.prompt_title or "Find"
-  local prompt_title = name .. " | <CR> select"
-  if opts.no_default_mappings then
-    return prompt_title
+---@return table|?
+local function get_entry_and_close(prompt_bufnr)
+  local entry = actions_state.get_selected_entry()
+  if entry then
+    telescope_actions.close(prompt_bufnr)
   end
-  local keys = self.client.opts.picker.mappings.new
-  if keys ~= nil then
-    prompt_title = prompt_title .. " | " .. keys .. " new"
-  end
-  keys = self.client.opts.picker.mappings.insert_link
-  if keys ~= nil then
-    prompt_title = prompt_title .. " | " .. keys .. " insert link"
-  end
-  return prompt_title
+  return entry
 end
 
 ---@param initial_query string|?
-TelescopePicker.default_mappings = function(self, map, initial_query)
-  -- Docs for telescope actions:
-  -- https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/actions/init.lua
-  local telescope_actions = require("telescope.actions.mt").transform_mod {
-    obsidian_new = function(prompt_bufnr)
-      local query = require("telescope.actions.state").get_current_line()
-      if not query or string.len(query) == 0 then
-        query = initial_query
-      end
-      require("telescope.actions").close(prompt_bufnr)
-      self.client:command("ObsidianNew", { args = query })
-    end,
-
-    obsidian_insert_link = function(prompt_bufnr)
-      require("telescope.actions").close(prompt_bufnr)
-      local path = require("telescope.actions.state").get_selected_entry().path
-      local note = require("obsidian").Note.from_file(path)
-      local link = self.client:format_link(note, {})
-      vim.api.nvim_put({ link }, "", false, true)
-    end,
-  }
-
-  local new_mapping = self.client.opts.picker.mappings.new
-  if new_mapping ~= nil then
-    map({ "i", "n" }, new_mapping, telescope_actions.obsidian_new)
+---@return string|?
+local function get_query_and_close(prompt_bufnr, initial_query)
+  local query = actions_state.get_current_line()
+  if not query or string.len(query) == 0 then
+    query = initial_query
   end
-
-  local insert_link_mapping = self.client.opts.picker.mappings.insert_link
-  if insert_link_mapping ~= nil then
-    map({ "i", "n" }, insert_link_mapping, telescope_actions.obsidian_insert_link)
+  if query and string.len(query) > 0 then
+    telescope_actions.close(prompt_bufnr)
+    return query
+  else
+    return nil
   end
-
-  return true
 end
 
----@param opts { prompt_title: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|?, dir: string|obsidian.Path|? }|?
+---@param map table
+---@param opts { callback: fun(path: string)|?, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|?, initial_query: string|? }
+local function attach_path_picker_mappings(map, opts)
+  -- Docs for telescope actions:
+  -- https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/actions/init.lua
+
+  if opts.query_mappings then
+    for key, mapping in pairs(opts.query_mappings) do
+      map({ "i", "n" }, key, function(prompt_bufnr)
+        local query = get_query_and_close(prompt_bufnr, opts.initial_query)
+        if query then
+          mapping.callback(query)
+        end
+      end)
+    end
+  end
+
+  if opts.selection_mappings then
+    for key, mapping in pairs(opts.selection_mappings) do
+      map({ "i", "n" }, key, function(prompt_bufnr)
+        local entry = get_entry_and_close(prompt_bufnr)
+        if entry then
+          mapping.callback(entry.path)
+        end
+      end)
+    end
+  end
+
+  if opts.callback then
+    map({ "i", "n" }, "<CR>", function(prompt_bufnr)
+      local entry = get_entry_and_close(prompt_bufnr)
+      if entry then
+        opts.callback(entry.path)
+      end
+    end)
+  end
+end
+
+---@param map table
+---@param opts { callback: fun(item: any)|?, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|? }
+local function attach_value_picker_mappings(map, opts)
+  if opts.query_mappings then
+    for key, mapping in pairs(opts.query_mappings) do
+      map({ "i", "n" }, key, function(prompt_bufnr)
+        local query = get_query_and_close(prompt_bufnr)
+        if query then
+          mapping.callback(query)
+        end
+      end)
+    end
+  end
+
+  if opts.selection_mappings then
+    for key, mapping in pairs(opts.selection_mappings) do
+      map({ "i", "n" }, key, function(prompt_bufnr)
+        local entry = get_entry_and_close(prompt_bufnr)
+        if entry then
+          mapping.callback(entry.value)
+        elseif mapping.fallback_to_query then
+          local query = get_query_and_close(prompt_bufnr)
+          if query then
+            mapping.callback(query)
+          end
+        end
+      end)
+    end
+  end
+
+  if opts.callback then
+    map({ "i", "n" }, "<CR>", function(prompt_bufnr)
+      local entry = get_entry_and_close(prompt_bufnr)
+      if entry then
+        opts.callback(entry.value)
+      end
+    end)
+  end
+end
+
+---@param opts obsidian.PickerFindOpts|? Options.
 TelescopePicker.find_files = function(self, opts)
-  opts = opts and opts or {}
+  opts = opts or {}
+
+  local prompt_title = self:_build_prompt {
+    prompt_title = opts.prompt_title,
+    query_mappings = opts.query_mappings,
+    selection_mappings = opts.selection_mappings,
+  }
+
   telescope.find_files {
-    prompt_title = self:prompt_title(opts),
+    prompt_title = prompt_title,
     cwd = opts.dir and tostring(opts.dir) or tostring(self.client.dir),
     find_command = self:_build_find_cmd(),
     attach_mappings = function(_, map)
-      if not opts.no_default_mappings then
-        self:default_mappings(map)
-      end
-
-      if opts.callback then
-        map({ "i", "n" }, "<CR>", function(prompt_bufnr)
-          local entry = require("telescope.actions.state").get_selected_entry()
-          require("telescope.actions").close(prompt_bufnr)
-          opts.callback(entry[1])
-        end)
-      end
-
+      attach_path_picker_mappings(
+        map,
+        { callback = opts.callback, query_mappings = opts.query_mappings, selection_mappings = opts.selection_mappings }
+      )
       return true
     end,
   }
 end
 
----@param opts { prompt_title: string|?, dir: string|obsidian.Path|?, query: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|? }|?
+---@param opts obsidian.PickerGrepOpts|? Options.
 TelescopePicker.grep = function(self, opts)
-  opts = opts and opts or {}
+  opts = opts or {}
 
   local cwd = opts.dir and Path:new(opts.dir) or self.client.dir
 
+  local prompt_title = self:_build_prompt {
+    prompt_title = opts.prompt_title,
+    query_mappings = opts.query_mappings,
+    selection_mappings = opts.selection_mappings,
+  }
+
   local attach_mappings = function(_, map)
-    if not opts.no_default_mappings then
-      self:default_mappings(map, opts.query)
-    end
-
-    if opts.callback then
-      map({ "i", "n" }, "<CR>", function(prompt_bufnr)
-        local filename = require("telescope.actions.state").get_selected_entry().filename
-        require("telescope.actions").close(prompt_bufnr)
-        opts.callback(tostring(cwd / filename))
-      end)
-    end
-
+    attach_path_picker_mappings(map, {
+      callback = opts.callback,
+      query_mappings = opts.query_mappings,
+      selection_mappings = opts.selection_mappings,
+      initial_query = opts.query,
+    })
     return true
   end
 
   if opts.query and string.len(opts.query) > 0 then
     telescope.grep_string {
-      prompt_title = self:prompt_title(opts),
+      prompt_title = prompt_title,
       cwd = tostring(cwd),
       vimgrep_arguments = self:_build_grep_cmd(),
       search = opts.query,
@@ -125,7 +172,7 @@ TelescopePicker.grep = function(self, opts)
     }
   else
     telescope.live_grep {
-      prompt_title = self:prompt_title(opts),
+      prompt_title = prompt_title,
       cwd = tostring(cwd),
       vimgrep_arguments = self:_build_grep_cmd(),
       attach_mappings = attach_mappings,
@@ -134,7 +181,7 @@ TelescopePicker.grep = function(self, opts)
 end
 
 ---@param values string[]|obsidian.PickerEntry[]
----@param opts { prompt_title: string|?, callback: fun(value: any)|? }|?
+---@param opts obsidian.PickerPickOpts|? Options.
 TelescopePicker.pick = function(self, values, opts)
   local pickers = require "telescope.pickers"
   local finders = require "telescope.finders"
@@ -145,14 +192,10 @@ TelescopePicker.pick = function(self, values, opts)
 
   local picker_opts = {
     attach_mappings = function(_, map)
-      if opts.callback then
-        map({ "i", "n" }, "<CR>", function(prompt_bufnr)
-          local entry = require("telescope.actions.state").get_selected_entry()
-          require("telescope.actions").close(prompt_bufnr)
-          opts.callback(entry.value)
-        end)
-      end
-
+      attach_value_picker_mappings(
+        map,
+        { callback = opts.callback, query_mappings = opts.query_mappings, selection_mappings = opts.selection_mappings }
+      )
       return true
     end,
   }
@@ -163,9 +206,15 @@ TelescopePicker.pick = function(self, values, opts)
     return self:_make_display(entry.raw)
   end
 
+  local prompt_title = self:_build_prompt {
+    prompt_title = opts.prompt_title,
+    query_mappings = opts.query_mappings,
+    selection_mappings = opts.selection_mappings,
+  }
+
   pickers
     .new(picker_opts, {
-      prompt_title = self:prompt_title { prompt_title = opts.prompt_title, no_default_mappings = true },
+      prompt_title = prompt_title,
       finder = finders.new_table {
         results = values,
         entry_maker = function(v)

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -24,7 +24,7 @@ end
 ---@class obsidian.PickerMappingOpts
 ---
 ---@field desc string
----@field callback fun(value: any)
+---@field callback fun(...)
 ---@field fallback_to_query boolean|?
 ---@field keep_open boolean|?
 ---@field allow_multiple boolean|?
@@ -100,7 +100,7 @@ end
 ---@class obsidian.PickerPickOpts
 ---
 ---@field prompt_title string|?
----@field callback fun(value: any)|?
+---@field callback fun(value: any, ...: any)|?
 ---@field allow_multiple boolean|?
 ---@field query_mappings obsidian.PickerMappingTable|?
 ---@field selection_mappings obsidian.PickerMappingTable|?
@@ -112,7 +112,7 @@ end
 ---
 --- Options:
 ---  `prompt_title`: Title for the prompt window.
----  `callback`: Callback to run with the selected item.
+---  `callback`: Callback to run with the selected item(s).
 ---  `allow_multiple`: Allow multiple selections to pass to the callback.
 ---  `query_mappings`: Mappings that run with the query prompt.
 ---  `selection_mappings`: Mappings that run with the current selection.
@@ -217,11 +217,11 @@ end
 --- Open picker with a list of tags.
 ---
 ---@param tags string[]
----@param opts { prompt_title: string|?, callback: fun(tag: string), allow_multiple: boolean|?, no_default_mappings: boolean|? }|? Options.
+---@param opts { prompt_title: string|?, callback: fun(tag: string, ...: string), allow_multiple: boolean|?, no_default_mappings: boolean|? }|? Options.
 ---
 --- Options:
 ---  `prompt_title`: Title for the prompt window.
----  `callback`: Callback to run with the selected tag.
+---  `callback`: Callback to run with the selected tag(s).
 ---  `allow_multiple`: Allow multiple selections to pass to the callback.
 ---  `no_default_mappings`: Don't apply picker's default mappings.
 Picker.pick_tag = function(self, tags, opts)

--- a/lua/obsidian/pickers/picker.lua
+++ b/lua/obsidian/pickers/picker.lua
@@ -2,6 +2,7 @@ local abc = require "obsidian.abc"
 local log = require "obsidian.log"
 local util = require "obsidian.util"
 local strings = require "plenary.strings"
+local Note = require "obsidian.note"
 
 ---@class obsidian.Picker : obsidian.ABC
 ---
@@ -14,42 +15,63 @@ Picker.new = function(client)
   return self
 end
 
----@param opts { prompt_title: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|?, dir: string|obsidian.Path|? }|?
+-------------------------------------------------------------------
+--- Abstract methods that need to be implemented by subclasses. ---
+-------------------------------------------------------------------
+
+---@alias obsidian.PickerMappingOpts { desc: string, callback: fun(value: any), fallback_to_query: boolean|? }
+
+---@alias obsidian.PickerMappingTable table<string, obsidian.PickerMappingOpts>
+
+---@class obsidian.PickerFindOpts
+---
+---@field prompt_title string|?
+---@field dir string|obsidian.Path|?
+---@field callback fun(path: string)|?
+---@field no_default_mappings boolean|?
+---@field query_mappings obsidian.PickerMappingTable|?
+---@field selection_mappings obsidian.PickerMappingTable|?
+
+--- Find files in a directory.
+---
+---@param opts obsidian.PickerFindOpts|? Options.
+---
+--- Options:
+---  `prompt_title`: Title for the prompt window.
+---  `dir`: Directory to search in.
+---  `callback`: Callback to run with the selected entry.
+---  `no_default_mappings`: Don't apply picker's default mappings.
+---  `query_mappings`: Mappings that run with the query prompt.
+---  `selection_mappings`: Mappings that run with the current selection.
+---
 ---@diagnostic disable-next-line: unused-local
 Picker.find_files = function(self, opts)
   error "not implemented"
 end
 
---- Find notes.
+---@class obsidian.PickerGrepOpts
 ---
----@param opts { prompt_title: string|?, callback: fun(path: string)|? }|?
-Picker.find_notes = function(self, opts)
-  opts = opts and opts or {}
-  return self:find_files { prompt_title = opts.prompt_title, callback = opts.callback }
-end
-
---- Find templates.
----
----@param opts { callback: fun(path: string) }
-Picker.find_templates = function(self, opts)
-  local templates_dir = self.client:templates_dir()
-
-  if templates_dir == nil then
-    log.err "Templates folder is not defined or does not exist"
-    return
-  end
-
-  return self:find_files {
-    prompt_title = "Templates",
-    callback = opts.callback,
-    dir = templates_dir,
-    no_default_mappings = true,
-  }
-end
+---@field prompt_title string|?
+---@field dir string|obsidian.Path|?
+---@field query string|?
+---@field callback fun(path: string)|?
+---@field no_default_mappings boolean|?
+---@field query_mappings obsidian.PickerMappingTable
+---@field selection_mappings obsidian.PickerMappingTable
 
 --- Grep for a string.
 ---
----@param opts { prompt_title: string|?, dir: string|obsidian.Path|?, query: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|? }|?
+---@param opts obsidian.PickerGrepOpts|? Options.
+---
+--- Options:
+---  `prompt_title`: Title for the prompt window.
+---  `dir`: Directory to search in.
+---  `query`: Initial query to grep for.
+---  `callback`: Callback to run with the selected path.
+---  `no_default_mappings`: Don't apply picker's default mappings.
+---  `query_mappings`: Mappings that run with the query prompt.
+---  `selection_mappings`: Mappings that run with the current selection.
+---
 ---@diagnostic disable-next-line: unused-local
 Picker.grep = function(self, opts)
   error "not implemented"
@@ -67,13 +89,256 @@ end
 ---@field icon string|?
 ---@field icon_hl string|?
 
---- Picker from a list of values.
+---@class obsidian.PickerPickOpts
 ---
----@param values string[]|obsidian.PickerEntry[]
----@param opts { prompt_title: string|?, callback: fun(value: any)|? }|?
+---@field prompt_title string|?
+---@field callback fun(value: any)|?
+---@field query_mappings obsidian.PickerMappingTable|?
+---@field selection_mappings obsidian.PickerMappingTable|?
+
+--- Pick from a list of items.
+---
+---@param values string[]|obsidian.PickerEntry[] Items to pick from.
+---@param opts obsidian.PickerPickOpts|? Options.
+---
+--- Options:
+---  `prompt_title`: Title for the prompt window.
+---  `callback`: Callback to run with the selected item.
+---  `query_mappings`: Mappings that run with the query prompt.
+---  `selection_mappings`: Mappings that run with the current selection.
+---
 ---@diagnostic disable-next-line: unused-local
 Picker.pick = function(self, values, opts)
   error "not implemented"
+end
+
+------------------------------------------------------------------
+--- Concrete methods with a default implementation subclasses. ---
+------------------------------------------------------------------
+
+--- Find notes by filename.
+---
+---@param opts { prompt_title: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|? }|? Options.
+---
+--- Options:
+---  `prompt_title`: Title for the prompt window.
+---  `callback`: Callback to run with the selected note path.
+---  `no_default_mappings`: Don't apply picker's default mappings.
+Picker.find_notes = function(self, opts)
+  opts = opts or {}
+
+  local query_mappings
+  local selection_mappings
+  if not opts.no_default_mappings then
+    query_mappings = self:_note_query_mappings()
+    selection_mappings = self:_note_selection_mappings()
+  end
+
+  return self:find_files {
+    prompt_title = opts.prompt_title or "Notes",
+    dir = self.client.dir,
+    callback = opts.callback,
+    no_default_mappings = opts.no_default_mappings,
+    query_mappings = query_mappings,
+    selection_mappings = selection_mappings,
+  }
+end
+
+--- Find templates by filename.
+---
+---@param opts { prompt_title: string|?, callback: fun(path: string) }|? Options.
+---
+--- Options:
+---  `callback`: Callback to run with the selected template path.
+Picker.find_templates = function(self, opts)
+  opts = opts or {}
+
+  local templates_dir = self.client:templates_dir()
+
+  if templates_dir == nil then
+    log.err "Templates folder is not defined or does not exist"
+    return
+  end
+
+  return self:find_files {
+    prompt_title = opts.prompt_title or "Templates",
+    callback = opts.callback,
+    dir = templates_dir,
+    no_default_mappings = true,
+  }
+end
+
+--- Grep search in notes.
+---
+---@param opts { prompt_title: string|?, query: string|?, callback: fun(path: string)|?, no_default_mappings: boolean|? }|? Options.
+---
+--- Options:
+---  `prompt_title`: Title for the prompt window.
+---  `query`: Initial query to grep for.
+---  `callback`: Callback to run with the selected path.
+---  `no_default_mappings`: Don't apply picker's default mappings.
+Picker.grep_notes = function(self, opts)
+  opts = opts or {}
+
+  local query_mappings
+  local selection_mappings
+  if not opts.no_default_mappings then
+    query_mappings = self:_note_query_mappings()
+    selection_mappings = self:_note_selection_mappings()
+  end
+
+  self:grep {
+    prompt_title = opts.prompt_title or "Grep notes",
+    dir = self.client.dir,
+    query = opts.query,
+    callback = opts.callback,
+    no_default_mappings = opts.no_default_mappings,
+    query_mappings = query_mappings,
+    selection_mappings = selection_mappings,
+  }
+end
+
+--- Open picker with a list of tags.
+---
+---@param tags string[]
+---@param opts { prompt_title: string|?, callback: fun(tag: string), no_default_mappings: boolean|? }|? Options.
+---
+--- Options:
+---  `prompt_title`: Title for the prompt window.
+---  `callback`: Callback to run with the selected tag.
+---  `no_default_mappings`: Don't apply picker's default mappings.
+Picker.pick_tag = function(self, tags, opts)
+  opts = opts or {}
+
+  local selection_mappings
+  if not opts.no_default_mappings then
+    selection_mappings = self:_tag_selection_mappings()
+  end
+
+  self:pick(tags, {
+    prompt_title = opts.prompt_title or "Tags",
+    callback = opts.callback,
+    no_default_mappings = opts.no_default_mappings,
+    selection_mappings = selection_mappings,
+  })
+end
+
+--------------------------------
+--- Concrete helper methods. ---
+--------------------------------
+
+---@param key string|?
+---@return boolean
+local function key_is_set(key)
+  if key ~= nil and string.len(key) > 0 then
+    return true
+  else
+    return false
+  end
+end
+
+--- Get query mappings to use for `find_notes()` or `grep_notes()`.
+---@return obsidian.PickerMappingTable
+Picker._note_query_mappings = function(self)
+  ---@type obsidian.PickerMappingTable
+  local mappings = {}
+
+  if self.client.opts.picker.note_mappings and key_is_set(self.client.opts.picker.note_mappings.new) then
+    mappings[self.client.opts.picker.note_mappings.new] = {
+      desc = "new",
+      callback = function(query)
+        self.client:command("ObsidianNew", { args = query })
+      end,
+    }
+  end
+
+  return mappings
+end
+
+--- Get selection mappings to use for `find_notes()` or `grep_notes()`.
+---@return obsidian.PickerMappingTable
+Picker._note_selection_mappings = function(self)
+  ---@type obsidian.PickerMappingTable
+  local mappings = {}
+
+  if self.client.opts.picker.note_mappings and key_is_set(self.client.opts.picker.note_mappings.insert_link) then
+    mappings[self.client.opts.picker.note_mappings.insert_link] = {
+      desc = "insert link",
+      callback = function(path)
+        local note = Note.from_file(path)
+        local link = self.client:format_link(note, {})
+        vim.api.nvim_put({ link }, "", false, true)
+      end,
+    }
+  end
+
+  return mappings
+end
+
+--- Get selection mappings to use for `pick_tag()`.
+---@return obsidian.PickerMappingTable
+Picker._tag_selection_mappings = function(self)
+  ---@type obsidian.PickerMappingTable
+  local mappings = {}
+
+  if self.client.opts.picker.tag_mappings then
+    if key_is_set(self.client.opts.picker.tag_mappings.tag_note) then
+      mappings[self.client.opts.picker.tag_mappings.tag_note] = {
+        desc = "tag note",
+        callback = function(tag)
+          local note = self.client:current_note()
+          if not note then
+            log.warn("'%s' is not a note in your workspace", vim.api.nvim_buf_get_name(0))
+            return
+          end
+
+          -- Add the tag and save the new frontmatter to the buffer.
+          note:add_tag(tag)
+          if self.client:update_frontmatter(note) then
+            log.info("Added tag '%s' to frontmatter", tag)
+          end
+        end,
+        fallback_to_query = true,
+      }
+    end
+
+    if key_is_set(self.client.opts.picker.tag_mappings.insert_tag) then
+      mappings[self.client.opts.picker.tag_mappings.insert_tag] = {
+        desc = "insert tag",
+        callback = function(tag)
+          vim.api.nvim_put({ "#" .. tag }, "", false, true)
+        end,
+        fallback_to_query = true,
+      }
+    end
+  end
+
+  return mappings
+end
+
+---@param opts { prompt_title: string, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|? }|?
+---@return string
+---@diagnostic disable-next-line: unused-local
+Picker._build_prompt = function(self, opts)
+  opts = opts or {}
+
+  ---@type string
+  local prompt = opts.prompt_title or "Find"
+  prompt = prompt .. " | <CR> select"
+
+  if opts.query_mappings then
+    for key, mapping in pairs(opts.query_mappings) do
+      prompt = prompt .. " | " .. key .. " " .. mapping.desc
+    end
+  end
+
+  if opts.selection_mappings then
+    for key, mapping in pairs(opts.selection_mappings) do
+      prompt = prompt .. " | " .. key .. " " .. mapping.desc
+    end
+  end
+
+  return prompt
 end
 
 ---@param entry obsidian.PickerEntry

--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -577,19 +577,22 @@ M.update = function(ui_opts, bufnr)
   update_extmarks(bufnr, ns_id, ui_opts)
 end
 
+---@param workspace obsidian.Workspace
 ---@param ui_opts obsidian.config.UIOpts
-M.setup = function(ui_opts)
+M.setup = function(workspace, ui_opts)
   if ui_opts.enable == false then
     return
   end
 
-  local group = vim.api.nvim_create_augroup("obsidian_ui", { clear = true })
+  local group = vim.api.nvim_create_augroup("ObsidianUI" .. workspace.name, { clear = true })
 
   install_hl_groups(ui_opts)
 
+  local pattern = tostring(workspace.root) .. "/**.md"
+
   vim.api.nvim_create_autocmd({ "BufEnter" }, {
     group = group,
-    pattern = "*.md",
+    pattern = pattern,
     callback = function()
       local conceallevel = vim.opt_local.conceallevel:get()
 
@@ -611,19 +614,19 @@ M.setup = function(ui_opts)
 
   vim.api.nvim_create_autocmd({ "BufEnter" }, {
     group = group,
-    pattern = "*.md",
+    pattern = pattern,
     callback = get_extmarks_autocmd_callback(ui_opts, false),
   })
 
   vim.api.nvim_create_autocmd({ "BufEnter", "TextChanged", "TextChangedI", "TextChangedP" }, {
     group = group,
-    pattern = "*.md",
+    pattern = pattern,
     callback = get_extmarks_autocmd_callback(ui_opts, true),
   })
 
   vim.api.nvim_create_autocmd({ "BufUnload" }, {
     group = group,
-    pattern = "*.md",
+    pattern = pattern,
     callback = function(ev)
       local ns_id = vim.api.nvim_create_namespace(NAMESPACE)
       cache_clear(ev.buf, ns_id)


### PR DESCRIPTION
Various improvements to the `Picker` API along with corresponding improvements `:ObsidianTags` command.

This command now has mappings for tagging the current note and inserting a tag. For pickers that allow it (telescope and fzf-lua) you can also select multiple tags at once and apply the mappings.

Closes #359.