### PR TITLE
Add basic callbacks system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ```
 
 - Added config option `picker.tag_mappings`, analogous to `picker.note_mappings`.
+- Added `log` field to `obsidian.Client` for easier access to the logger.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a configurable callback system to further customize obsidian.nvim's behavior. Callbacks are defined through the `callbacks` field in the config:
+
+    ```lua
+    callbacks = {
+      -- Runs at the end of `require("obsidian").setup()`.
+      ---@param client obsidian.Client
+      post_setup = function(client) end,
+
+      -- Runs anytime you enter the buffer for a note.
+      ---@param client obsidian.Client
+      ---@param note obsidian.Note
+      enter_note = function(client, note) end,
+
+      -- Runs right before writing the buffer for a note.
+      ---@param client obsidian.Client
+      ---@param note obsidian.Note
+      pre_write_note = function(client, note) end,
+    }
+    ```
+
 - Added configuration option `note_path_func(spec): obsidian.Path` for customizing how file names for new notes are generated. This takes a single argument, a table that looks like `{ id: string, dir: obsidian.Path, title: string|? }`, and returns an `obsidian.Path` object. The default behavior is equivalent to this:
 
     ```lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       ---@param client obsidian.Client
       ---@param note obsidian.Note
       pre_write_note = function(client, note) end,
+
+      -- Runs anytime the workspace is set/changed.
+      ---@param client obsidian.Client
+      ---@param workspace obsidian.Workspace
+      ---@diagnostic disable-next-line: unused-local
+      post_set_workspace = function(client, workspace) end,
     }
     ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       -- Runs anytime the workspace is set/changed.
       ---@param client obsidian.Client
       ---@param workspace obsidian.Workspace
-      ---@diagnostic disable-next-line: unused-local
       post_set_workspace = function(client, workspace) end,
     }
     ```

--- a/README.md
+++ b/README.md
@@ -418,6 +418,23 @@ This is a complete list of all of the options that can be passed to `require("ob
   -- 3. "hsplit" - to open in a horizontal split if there's not already a horizontal split
   open_notes_in = "current",
 
+  -- Optional, define your own callbacks to further customize behavior.
+  callbacks = {
+    -- Runs at the end of `require("obsidian").setup()`.
+    ---@param client obsidian.Client
+    post_setup = function(client) end,
+
+    -- Runs anytime you enter the buffer for a note.
+    ---@param client obsidian.Client
+    ---@param note obsidian.Note
+    enter_note = function(client, note) end,
+
+    -- Runs right before writing the buffer for a note.
+    ---@param client obsidian.Client
+    ---@param note obsidian.Note
+    pre_write_note = function(client, note) end,
+  },
+
   -- Optional, configure additional syntax highlighting / extmarks.
   -- This requires you have `conceallevel` set to 1 or 2. See `:help conceallevel` for more details.
   ui = {

--- a/README.md
+++ b/README.md
@@ -433,6 +433,11 @@ This is a complete list of all of the options that can be passed to `require("ob
     ---@param client obsidian.Client
     ---@param note obsidian.Note
     pre_write_note = function(client, note) end,
+
+    -- Runs anytime the workspace is set/changed.
+    ---@param client obsidian.Client
+    ---@param workspace obsidian.Workspace
+    post_set_workspace = function(client, workspace) end,
   },
 
   -- Optional, configure additional syntax highlighting / extmarks.

--- a/lua/obsidian/callbacks.lua
+++ b/lua/obsidian/callbacks.lua
@@ -7,7 +7,7 @@ local M = {}
 ---
 ---@field client obsidian.Client
 ---@field callbacks obsidian.config.CallbackConfig
-CallbackManager = abc.new_class()
+local CallbackManager = abc.new_class()
 M.CallbackManager = CallbackManager
 
 ---@param client obsidian.Client

--- a/lua/obsidian/callbacks.lua
+++ b/lua/obsidian/callbacks.lua
@@ -56,4 +56,12 @@ CallbackManager.pre_write_note = function(self, note)
   end
 end
 
+---@param workspace obsidian.Workspace
+---@return boolean|? success
+CallbackManager.post_set_workspace = function(self, workspace)
+  if self.callbacks.post_set_workspace then
+    return fire_callback("post_set_workspace", self.callbacks.post_set_workspace, self.client, workspace)
+  end
+end
+
 return M

--- a/lua/obsidian/callbacks.lua
+++ b/lua/obsidian/callbacks.lua
@@ -1,0 +1,59 @@
+local abc = require "obsidian.abc"
+local log = require "obsidian.log"
+
+local M = {}
+
+---@class obsidian.CallbackManager : obsidian.ABC
+---
+---@field client obsidian.Client
+---@field callbacks obsidian.config.CallbackConfig
+CallbackManager = abc.new_class()
+M.CallbackManager = CallbackManager
+
+---@param client obsidian.Client
+---@param callbacks obsidian.config.CallbackConfig
+CallbackManager.new = function(client, callbacks)
+  local self = CallbackManager.init()
+  self.client = client
+  self.callbacks = callbacks
+  return self
+end
+
+---@param event string
+---@param callback fun(...)
+---@param ... any
+---@return boolean success
+local function fire_callback(event, callback, ...)
+  local ok, err = pcall(callback, ...)
+  if ok then
+    return true
+  else
+    log.error("Error running %s callback: %s", event, err)
+    return false
+  end
+end
+
+---@return boolean|? success
+CallbackManager.post_setup = function(self)
+  if self.callbacks.post_setup then
+    return fire_callback("post_setup", self.callbacks.post_setup, self.client)
+  end
+end
+
+---@param note obsidian.Note
+---@return boolean|? success
+CallbackManager.enter_note = function(self, note)
+  if self.callbacks.enter_note then
+    return fire_callback("enter_note", self.callbacks.enter_note, self.client, note)
+  end
+end
+
+---@param note obsidian.Note
+---@return boolean|? success
+CallbackManager.pre_write_note = function(self, note)
+  if self.callbacks.pre_write_note then
+    return fire_callback("pre_write_note", self.callbacks.pre_write_note, self.client, note)
+  end
+end
+
+return M

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -19,6 +19,7 @@ local log = require "obsidian.log"
 local util = require "obsidian.util"
 local search = require "obsidian.search"
 local AsyncExecutor = require("obsidian.async").AsyncExecutor
+local CallbackManager = require("obsidian.callbacks").CallbackManager
 local block_on = require("obsidian.async").block_on
 local iter = require("obsidian.itertools").iter
 
@@ -63,6 +64,7 @@ end
 ---@field dir obsidian.Path The root of the vault for the current workspace.
 ---@field opts obsidian.config.ClientOpts The client config.
 ---@field buf_dir obsidian.Path|? The parent directory of the current buffer.
+---@field callback_manager obsidian.CallbackManager
 ---@field _default_opts obsidian.config.ClientOpts
 ---@field _quiet boolean
 local Client = abc.new_class {
@@ -116,6 +118,9 @@ Client.set_workspace = function(self, workspace, opts)
     local daily_notes_subdir = self.dir / self.opts.daily_notes.folder
     daily_notes_subdir:mkdir { parents = true, exists_ok = true }
   end
+
+  -- Initialize callback manager.
+  self.callback_manager = CallbackManager.new(self, self.opts.callbacks)
 
   -- Setup UI add-ons.
   if self.opts.ui.enable then

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -65,6 +65,7 @@ end
 ---@field opts obsidian.config.ClientOpts The client config.
 ---@field buf_dir obsidian.Path|? The parent directory of the current buffer.
 ---@field callback_manager obsidian.CallbackManager
+---@field log obsidian.Logger
 ---@field _default_opts obsidian.config.ClientOpts
 ---@field _quiet boolean
 local Client = abc.new_class {
@@ -85,6 +86,7 @@ local Client = abc.new_class {
 Client.new = function(opts)
   local self = Client.init()
 
+  self.log = log
   self._default_opts = opts
   self._quiet = false
 

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -130,6 +130,8 @@ Client.set_workspace = function(self, workspace, opts)
   if opts.lock then
     self.current_workspace:lock()
   end
+
+  self.callback_manager:post_set_workspace(workspace)
 end
 
 --- Get the normalize opts for a given workspace.

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -454,6 +454,7 @@ end
 ---@field post_setup fun(client: obsidian.Client)|? Runs right after the `obsidian.Client` is initialized.
 ---@field enter_note fun(client: obsidian.Client, note: obsidian.Note)|? Runs when entering a note buffer.
 ---@field pre_write_note fun(client: obsidian.Client, note: obsidian.Note)|? Runs right before writing a note buffer.
+---@field post_set_workspace fun(client: obsidian.Client, workspace: obsidian.Workspace)|? Runs anytime the workspace is set/changed.
 config.CallbackConfig = {}
 
 ---@return obsidian.config.CallbackConfig

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -30,6 +30,7 @@ local config = {}
 ---@field open_notes_in obsidian.config.OpenStrategy
 ---@field ui obsidian.config.UIOpts
 ---@field attachments obsidian.config.AttachmentsOpts
+---@field callbacks obsidian.config.CallbackConfig
 config.ClientOpts = {}
 
 --- Get defaults.
@@ -61,6 +62,7 @@ config.ClientOpts.default = function()
     open_notes_in = "current",
     ui = config.UIOpts.default(),
     attachments = config.AttachmentsOpts.default(),
+    callbacks = config.CallbackConfig.default(),
   }
 end
 
@@ -418,7 +420,7 @@ end
 ---@class obsidian.config.AttachmentsOpts
 ---
 ---@field img_folder string Default folder to save images to, relative to the vault root.
----@field img_text_func function (obsidian.Client, Path,) -> string
+---@field img_text_func fun(client: obsidian.Client, path: obsidian.Path): string
 ---@field confirm_img_paste boolean Whether to confirm the paste or not. Defaults to true.
 config.AttachmentsOpts = {}
 
@@ -445,6 +447,18 @@ config.AttachmentsOpts.default = function()
     end,
     confirm_img_paste = true,
   }
+end
+
+---@class obsidian.config.CallbackConfig
+---
+---@field post_setup fun(client: obsidian.Client)|? Runs right after the `obsidian.Client` is initialized.
+---@field enter_note fun(client: obsidian.Client, note: obsidian.Note)|? Runs when entering a note buffer.
+---@field pre_write_note fun(client: obsidian.Client, note: obsidian.Note)|? Runs right before writing a note buffer.
+config.CallbackConfig = {}
+
+---@return obsidian.config.CallbackConfig
+config.CallbackConfig.default = function()
+  return {}
 end
 
 return config

--- a/lua/obsidian/log.lua
+++ b/lua/obsidian/log.lua
@@ -1,3 +1,4 @@
+---@class obsidian.Logger
 local log = {}
 
 log._log_level = vim.log.levels.INFO
@@ -46,7 +47,7 @@ log.set_level = function(level)
   log._log_level = level
 end
 
----Log a message.
+--- Log a message.
 ---
 ---@param msg any
 ---@param level integer|?


### PR DESCRIPTION
This PR adds a basic configurable callback system defined in the `callbacks` config field:

```lua
callbacks = {
  -- Runs at the end of `require("obsidian").setup()`.
  ---@param client obsidian.Client
  post_setup = function(client) end,

  -- Runs anytime you enter the buffer for a note.
  ---@param client obsidian.Client
  ---@param note obsidian.Note
  enter_note = function(client, note) end,

  -- Runs right before writing the buffer for a note.
  ---@param client obsidian.Client
  ---@param note obsidian.Note
  pre_write_note = function(client, note) end,

  -- Runs anytime the workspace is set/changed.
  ---@param client obsidian.Client
  ---@param workspace obsidian.Workspace
  post_set_workspace = function(client, workspace) end,
}
```