### PR TITLE
Fix :ObsidianOpen bug on Windows

### DIFF
--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -67,7 +67,7 @@ return function(client, data)
     args = { uri }
   elseif this_os == util.OSType.Windows then
     cmd = "powershell"
-    args = { "Start-Process '" .. uri .. "'" }
+    args = { "Start-Process", uri }
   elseif this_os == util.OSType.Darwin then
     cmd = "open"
     if client.opts.open_app_foreground then
@@ -83,7 +83,7 @@ return function(client, data)
   assert(cmd)
   assert(args)
 
-  local cmd_with_args = cmd .. " " .. table.concat(args, " ")
+  local cmd_with_args = {cmd, unpack(args)}
   vim.fn.jobstart(cmd_with_args, {
     detach = true,
     on_exit = function(_, exit_code)

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -83,7 +83,7 @@ return function(client, data)
   assert(cmd)
   assert(args)
 
-  local cmd_with_args = {cmd, unpack(args)}
+  local cmd_with_args = { cmd, unpack(args) }
   vim.fn.jobstart(cmd_with_args, {
     on_exit = function(_, exit_code)
       if exit_code ~= 0 then

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -85,7 +85,6 @@ return function(client, data)
 
   local cmd_with_args = {cmd, unpack(args)}
   vim.fn.jobstart(cmd_with_args, {
-    detach = true,
     on_exit = function(_, exit_code)
       if exit_code ~= 0 then
         log.err("open command failed with exit code '%s': %s", exit_code, cmd_with_args)


### PR DESCRIPTION
The `ObsidianOpen` command failed to open the Obsidian app when not using WSL on Windows. For reasons I do not know, adding the `detach` option to `vim.fn.jobstart` causes the command to fail. Additionally, passing a string instead of a table to `vim.fn.jobstart` also causes the command to fail. 

Fix #448 