### PR TITLE
fix(logger): gsub got passed nil, because `msg` wasn't passed properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Full changelog below 👇
 - Respect telescope.nvim themes configured by user.
 - Make tags completion more efficient (less CPU time!).
 - Added file/directory completion to image name prompt from `:ObsidianPasteImg`.
+- Fixed bug with setup error when getting a deprecation warning.
 
 ## [v3.6.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.6.1) - 2024-02-28
 

--- a/lua/obsidian/log.lua
+++ b/lua/obsidian/log.lua
@@ -113,11 +113,11 @@ end
 
 ---Log a message only once.
 ---
----@param msg any
+---@param msg string
 ---@param level integer|?
 log.log_once = function(msg, level, ...)
   if level == nil or log._log_level == nil or level >= log._log_level then
-    msg = string.format(tostring(msg), unpack(message_args(...)))
+    msg = string.format(tostring(msg), unpack(message_args(msg, ...)))
     if vim.in_fast_event() then
       vim.schedule(function()
         vim.notify_once(msg, level, { title = "Obsidian.nvim" })


### PR DESCRIPTION
fixes #465

msg wasn't passed to `message_args` properly, leading to nil pointer dereference.