### PR TITLE
fix: handle timer nil value in async.throttle function

### DIFF
--- a/lua/obsidian/async.lua
+++ b/lua/obsidian/async.lua
@@ -422,9 +422,11 @@ M.throttle = function(fn, timeout)
         ms_remaining,
         0,
         vim.schedule_wrap(function()
-          timer:stop()
-          timer:close()
-          timer = nil
+          if timer ~= nil then
+            timer:stop()
+            timer:close()
+            timer = nil
+          end
           ---@diagnostic disable-next-line: undefined-field
           last_call = vim.loop.now()
           fn(unpack(args))


### PR DESCRIPTION
I had regularly the following error thrown after typing a few characters to get suggestions in an opened wikilink (`[[`):

```txt
Error executing vim.schedule lua callback: ...k/devPackages/start/obsidian.nvim/lua/obsidian/async.lua:426: attempt to index upvalue 'timer' (a nil value)
stack traceback:
        ...k/devPackages/start/obsidian.nvim/lua/obsidian/async.lua:426: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

It looks like `timer` can be `nil` in the callback function. A simple check for the `nil` case in the function fixed my bug. I did not really investigate, this might not be the optimal solution.