### PR TITLE
provide consistency between daily notes frontmatter with/without temp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Full changelog below 👇
 
 ### Fixed
 
+- Fixed consistency in frontmatter between opening daily notes with or without a template
 - Fixed issue with `:ObsidianOpen` on windows.
 - Respect telescope.nvim themes configured by user.
 - Make tags completion more efficient (less CPU time!).

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1716,6 +1716,9 @@ Client._daily = function(self, datetime)
       note = Note.from_file(path)
       if note.has_frontmatter then
         write_frontmatter = false
+      else
+        note.aliases = { alias }
+        note.tags = { "daily-notes" }
       end
     end
 


### PR DESCRIPTION
Previously when opening a daily note using a template which does not include frontmatter, the default note frontmatter would be used. To me, it feels more consistent to use the default daily frontmatter in this case.