### PR TITLE
added more examples for template.substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,10 +681,80 @@ templates = {
   substitutions = {
     yesterday = function()
       return os.date("%Y-%m-%d", os.time() - 86400)
-    end
+    end,
+    -- Additional template substitutions
+    time24 = function()
+      return os.date('%H:%M:%S')
+    end,
+    time12 = function()
+      -- Conversion to 12-hour format with AM/PM
+      local hour = tonumber(os.date('%H'))
+      local ampm = hour >= 12 and 'PM' or 'AM'
+      hour = hour % 12
+      hour = hour == 0 and 12 or hour
+      return string.format('%02d:%s %s', hour, os.date('%M:%S'), ampm)
+    end,
+    year = function()
+      return os.date('%Y', os.time())
+    end,
+    month = function()
+      return os.date('%B', os.time())
+    end,
+    nextday = function()
+      return os.date('%Y-%m-%d', os.time() + 86400)
+    end,
+    hdate = function()
+      return os.date('%A, %B %d, %Y')
+    end,
+    rfc3339 = function()
+      return os.date('!%Y-%m-%dT%H:%M:%SZ')
+    end,
+    week = function()
+      return os.date('%V', os.time())
+    end,
+    isoweek = function()
+      return os.date('%G-W%V', os.time())
+    end,
+    isoprevweek = function()
+      local adjustment = -7 * 24 * 60 * 60 -- One week in seconds
+      return os.date('%G-W%V', os.time() + adjustment)
+    end,
+    isonextweek = function()
+      local adjustment = 7 * 24 * 60 * 60 -- One week in seconds
+      return os.date('%G-W%V', os.time() + adjustment)
+    end,
+    day_of_month = function()
+      return os.date('%d', os.time())
+    end,
+    month_numeric = function()
+      return os.date('%m', os.time())
+    end,
+    weekday = function()
+      return os.date('%A', os.time())
+    end,
   }
 }
 ```
+
+Below is a detailed table of custom variables available for template substitutions.
+
+| Specifier           | Expands to                                  | Example                               |
+|---------------------|---------------------------------------------|---------------------------------------|
+| `{{time24}}`        | Current time in 24-hour format              | "14:45:00"                            |
+| `{{time12}}`        | Current time in 12-hour format with AM/PM   | "2:45:00 PM"                          |
+| `{{year}}`          | Current year                                | "2024"                                |
+| `{{month}}`         | Month name                                  | "March"                               |
+| `{{yesterday}}`     | Yesterday’s date in ISO format              | "2024-03-05"                          |
+| `{{nextday}}`       | Tomorrow’s date in ISO format               | "2024-03-07"                          |
+| `{{hdate}}`         | Current date in a human-readable format     | "Wednesday, March 6, 2024"            |
+| `{{rfc3339}}`       | Current date and time in RFC3339 format     | "2024-03-06T14:45:00+00:00"           |
+| `{{week}}`          | Week number of the year                     | "10"                                  |
+| `{{isoweek}}`       | ISO week number of the current week         | "2024-W10"                            |
+| `{{isoprevweek}}`   | ISO week number of the previous week        | "2024-W09"                            |
+| `{{isonextweek}}`   | ISO week number of the next week            | "2024-W11"                            |
+| `{{day_of_month}}`  | Day of the month                            | "06"                                  |
+| `{{month_numeric}}` | Month as a numeric value                    | "03"                                  |
+| `{{weekday}}`       | Name of the weekday                         | "Wednesday"                           |
 
 ### Usage outside of a workspace or vault
 


### PR DESCRIPTION
I've added new template substitutions to increase the flexibility and usability. These additions provide more options for users to format dates and times according to their preferences and requirements. Here's a quick summary of some of them:

- **Enhanced Time and Date Formatting**: With substitutions like `{{time24}}`, `{{time12}}`, and `{{nextday}}`, users can tailor time and date displays to their liking, supporting various international formats.

- **Week and Year Info**: New options like `{{week}}`, `{{isoweek}}`, `{{isoprevweek}}`, and `{{isonextweek}}` help in tracking and planning by week numbers, aligning with ISO standards.

- **Readable and Technical Date Formats**: The `{{hdate}}` and `{{rfc3339}}` substitutions cater to both user-friendly displays and integration needs requiring precise, standardized formats.

I hope this can be useful. 

I also tested the results from ./panvimdoc.sh ... And it looks ok