### PR TITLE
Mark configuration fields optional to make lua lsp's diagnostics happy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Full changelog below 👇
 - Make tags completion more efficient (less CPU time!).
 - Added file/directory completion to image name prompt from `:ObsidianPasteImg`.
 - Handle prompt cancellation gracefully.
+- Fix lua diagnostic warnings about missing fields in the configuration
 
 ## [v3.6.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.6.1) - 2024-02-28
 

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -28,7 +28,7 @@ local config = {}
 ---@field sort_by obsidian.config.SortBy|?
 ---@field sort_reversed boolean|?
 ---@field open_notes_in obsidian.config.OpenStrategy
----@field ui obsidian.config.UIOpts
+---@field ui obsidian.config.UIOpts | table<string, any>
 ---@field attachments obsidian.config.AttachmentsOpts
 ---@field callbacks obsidian.config.CallbackConfig
 config.ClientOpts = {}
@@ -381,13 +381,13 @@ end
 ---
 ---@field enable boolean
 ---@field update_debounce integer
----@field checkboxes table{string, obsidian.config.UICharSpec}
+---@field checkboxes table<string, obsidian.config.UICharSpec>
 ---@field bullets obsidian.config.UICharSpec|?
 ---@field external_link_icon obsidian.config.UICharSpec
 ---@field reference_text obsidian.config.UIStyleSpec
 ---@field highlight_text obsidian.config.UIStyleSpec
 ---@field tags obsidian.config.UIStyleSpec
----@field hl_groups table{string, table}
+---@field hl_groups table<string, table>
 config.UIOpts = {}
 
 ---@class obsidian.config.UICharSpec

--- a/lua/obsidian/init.lua
+++ b/lua/obsidian/init.lua
@@ -87,7 +87,7 @@ end
 
 --- Setup a new Obsidian client. This should only be called once from an Nvim session.
 ---
----@param opts obsidian.config.ClientOpts
+---@param opts obsidian.config.ClientOpts | table<string, any>
 ---
 ---@return obsidian.Client
 obsidian.setup = function(opts)


### PR DESCRIPTION
# Problem

A user of the library receives warnings from LUA LSP's diagnostic, about some configuration parameters are missing, even tho they are not strictly required

<img width="706" alt="image" src="https://github.com/epwalsh/obsidian.nvim/assets/2971720/167188d1-b340-469a-9a48-80a7b2ff1fbd">

# Solution
Annotate configuration fields as optional