### PR TITLE
fix: renaming sends proper path to joinpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed renaming when passing file path
+
 ## [v3.7.1](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.1) - 2024-03-09
 
 ### Fixed

--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -93,8 +93,7 @@ return function(client, data)
   local new_note_path
   if #parts > 1 then
     parts[#parts] = nil
-    new_note_path =
-      client.dir.joinpath(unpack(vim.tbl_flatten { tostring(client.dir), parts, new_note_id })):with_suffix ".md"
+    new_note_path = client.dir.joinpath(client.dir, unpack(vim.tbl_flatten { parts, new_note_id })):with_suffix ".md"
   else
     new_note_path = (dirname / new_note_id):with_suffix ".md"
   end

--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -93,7 +93,7 @@ return function(client, data)
   local new_note_path
   if #parts > 1 then
     parts[#parts] = nil
-    new_note_path = client.dir.joinpath(client.dir, unpack(vim.tbl_flatten { parts, new_note_id })):with_suffix ".md"
+    new_note_path = client.dir:joinpath(unpack(vim.tbl_flatten { parts, new_note_id })):with_suffix ".md"
   else
     new_note_path = (dirname / new_note_id):with_suffix ".md"
   end


### PR DESCRIPTION
Fixes #486

Currently self.filename is `nil` because string is passed as self.