### PR TITLE
fix: erroneous title in daily note creation from template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't open picker for tags when there aren't any matches.
+- Fix incorrect initialization of the daily note alias to a timestamp.
 - Correctly replace the `{{title}}` template parameter with filename in daily notes.
 
 ## [v3.7.3](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.3) - 2024-03-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't open picker for tags when there aren't any matches.
+- Correctly replace the `{{title}}` template parameter with filename in daily notes.
 
 ## [v3.7.3](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.3) - 2024-03-13
 

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1886,7 +1886,7 @@ Client._daily = function(self, datetime, opts)
   if self.opts.daily_notes.alias_format ~= nil then
     alias = tostring(os.date(self.opts.daily_notes.alias_format, datetime))
   else
-    alias = tostring(os.date("%B %-d, %Y", datetime))
+    alias = tostring(os.date("%B %d, %Y", datetime))
   end
 
   ---@type obsidian.Note

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1895,7 +1895,7 @@ Client._daily = function(self, datetime, opts)
     note = Note.from_file(path, opts.load)
   else
     note = Note.new(id, { alias }, { "daily-notes" }, path)
-    note.title = alias
+    note.title = id
     if not opts.no_write then
       self:write_note(note, { template = self.opts.daily_notes.template })
     end


### PR DESCRIPTION
The `{{title}}` template parameter would get incorrectly replaced with the alias, which is a big number, presumably being the creation timestamp. The expected behavior is to replace it with filename.

## Example

The template:
```md
# {{title}}

```

The created daily note (filename: 2024-03-16.md):

```md
# 1710608450

```
