### PR TITLE
fix: recover toggle_checkbox util's condition to create a checkbox with a line without a checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed regression with toggle checkbox util/mapping.
+
 ## [v3.7.7](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.7) - 2024-04-05
 
 ### Fixed
 
 - Removed excessive logging when running `:ObsidianToday` command with a defined template, resulting in cleaner output and a more streamlined user experience.
-
-* Fixed bug with toggle checkbox util where original create new checkbox should be retained
 
 ## [v3.7.6](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.6) - 2024-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed excessive logging when running `:ObsidianToday` command with a defined template, resulting in cleaner output and a more streamlined user experience.
 
+* Fixed bug with toggle checkbox util where original create new checkbox should be retained
+
 ## [v3.7.6](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.6) - 2024-04-01
 
 ### Fixed

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -501,12 +501,14 @@ util.toggle_checkbox = function(opts)
   local checkboxes = opts or { " ", "x" }
 
   if not string.match(line, checkbox_pattern) then
+    if opts then -- not create new checkbox with command
+      return
+    end
     local unordered_list_pattern = "^(%s*)[-*+] (.*)"
-
     if string.match(line, unordered_list_pattern) then
       line = string.gsub(line, unordered_list_pattern, "%1- [ ] %2")
     else
-      return
+      line = string.gsub(line, "^(%s*)", "%1- [ ] ")
     end
   else
     for i, check_char in enumerate(checkboxes) do


### PR DESCRIPTION
recover toggle_checkbox util's condition to create a checkbox with a line without a checkbox for backwards compatibility (#531)