### PR TITLE
fix: ensure template insertion to occur at the current line.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed an issue where template insertion occurred below the intended line, it now correctly inserts at the current line.
+
 ## [v3.7.8](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.8) - 2024-04-09
 
 ### Fixed

--- a/lua/obsidian/templates.lua
+++ b/lua/obsidian/templates.lua
@@ -176,7 +176,7 @@ M.insert_template = function(opts)
     error(string.format("Template file '%s' not found", template_path))
   end
 
-  vim.api.nvim_buf_set_lines(buf, row, row, false, insert_lines)
+  vim.api.nvim_buf_set_lines(buf, row - 1, row - 1, false, insert_lines)
   local new_cursor_row, _ = unpack(vim.api.nvim_win_get_cursor(win))
   vim.api.nvim_win_set_cursor(0, { new_cursor_row, 0 })
 


### PR DESCRIPTION
`nvim_buf_set_lines` function uses zero-based indexing while `nvim_win_get_cursor` returns (1,0)-indexed cursor position.
This caused templates to be inserted one line below the expected cursor position. 

Additionally, users were unable to customize the frontmatter in their templates due to it being placed on the second line, which was not recognized properly by obsidian.nvim. (#534)