### PR TITLE
fix: os_uname check for wsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed an issue where template insertion occurred below the intended line, it now correctly inserts at the current line.
+- Fixed `:ObsidianOpen` issue on WSL OS name identifier check with different release name case.
 
 ## [v3.7.8](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.8) - 2024-04-09
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -437,9 +437,9 @@ util.get_os = function()
   if vim.fn.has "win32" == 1 then
     this_os = util.OSType.Windows
   else
-    local sysname = vim.loop.os_uname().sysname
-    local release = vim.loop.os_uname().release
-    if sysname == "Linux" and string.find(release, "microsoft") then
+    local sysname = vim.loop.os_uname().sysname:lower()
+    local release = vim.loop.os_uname().release:lower()
+    if sysname == "linux" and string.find(release, "microsoft") then
       this_os = util.OSType.Wsl
     else
       this_os = sysname


### PR DESCRIPTION
This PR resolves https://github.com/epwalsh/obsidian.nvim/issues/542.

## 📝 Change Summary

* Provide case-insensitive check for both of the `sysname` and `release` to handle the case with the following values:
```
sysname='Linux'
release='4.4.0-19041-Microsoft'
```
