### PR TITLE
Add optional line number argument to toggle_checkbox, defaulting to the current line number if not provided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added an optional line number argument for toggle_checkbox, that defaults to the current line.
+
 ### Fixed
 
 - Ensure toggle checkbox mapping uses checkbox configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added an optional line number argument for toggle_checkbox, that defaults to the current line.
+- Added an optional line number argument for `util.toggle_checkbox()`, that defaults to the current line.
 
 ### Fixed
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -496,7 +496,7 @@ end
 util.toggle_checkbox = function(opts, line_num)
   -- Allow line_num to be optional, defaulting to the current line if not provided
   line_num = line_num or unpack(vim.api.nvim_win_get_cursor(0))
-  local line = vim.api.nvim_get_current_line()
+  local line = vim.api.nvim_buf_get_lines(0, line_num - 1, line_num, false)[1]
 
   local checkbox_pattern = "^%s*- %[.] "
   local checkboxes = opts or { " ", "x" }

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -493,8 +493,9 @@ util.zettel_id = function()
 end
 
 ---Toggle the checkbox on the line that the cursor is on.
-util.toggle_checkbox = function(opts)
-  local line_num = unpack(vim.api.nvim_win_get_cursor(0)) -- 1-indexed
+util.toggle_checkbox = function(opts, line_num)
+  -- Allow line_num to be optional, defaulting to the current line if not provided
+  line_num = line_num or unpack(vim.api.nvim_win_get_cursor(0))
   local line = vim.api.nvim_get_current_line()
 
   local checkbox_pattern = "^%s*- %[.] "


### PR DESCRIPTION
I was hoping to add an optional line argument to toggle_checkbox, so I could checkboxify lines in mass.

My lua/nvim experience is very limited. ChatGPT guided my hand. I can follow up with proper documentation, but wanted to run this by somebody to ensure i'm not duplicating effort and to verify that this is not a bad idea.