### PR TITLE
vim.tbl_islist will be deprecated in nvim 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Changed `vim.tbl_islist` to `vim.islist` sice it is removed in Nvim 0.12
+
 ### Fixed
 
 - Made workspace detection more robust.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Changed `vim.tbl_islist` to `vim.islist` sice it is removed in Nvim 0.12
+- Changed `vim.tbl_islist` to `vim.islist` since it is removed in Nvim 0.12
 
 ### Fixed
 

--- a/lua/obsidian/itertools.lua
+++ b/lua/obsidian/itertools.lua
@@ -26,7 +26,7 @@ M.iter = function(iterable)
       return function()
         return nil
       end
-    elseif vim.tbl_islist(iterable) then
+    elseif vim.islist(iterable) then
       local i = 1
       local n = #iterable
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -44,7 +44,7 @@ util.tbl_is_array = function(t)
     return false
   end
 
-  return vim.tbl_islist(t)
+  return vim.islist(t)
 end
 
 ---Check if an object is an non-array table.


### PR DESCRIPTION
Thank you for developing great plugin!

I'm using `NVIM v0.11.0` and I got following warnings that `vim.tbl_islist` will be deprecated in `NVIM v0.12`.
So I fixed  `vim.tbl_islist` to `vim.islist`.

<img width="480" alt="Screenshot 2024-05-20 at 9 44 58" src="https://github.com/epwalsh/obsidian.nvim/assets/37134200/e4a8fa0a-8255-4735-8953-29cffe8b025a">
