### PR TITLE
fix: upgrade to vim.islist without errors

### DIFF
--- a/lua/obsidian/compat.lua
+++ b/lua/obsidian/compat.lua
@@ -1,6 +1,12 @@
 local compat = {}
 
-compat.is_list = vim.islist or vim.tbl_islist
+compat.is_list = function(t)
+  if vim.fn.has "nvim-0.11" == 1 then
+    return vim.islist(t)
+  else
+    return vim.tbl_islist(t)
+  end
+end
 
 compat.flatten = function(t)
   if vim.fn.has "nvim-0.11" == 1 then


### PR DESCRIPTION
Was getting an error when starting up neovim sourced from this plugin:
<img width="532" alt="image" src="https://github.com/epwalsh/obsidian.nvim/assets/112036395/3b966dbf-6394-4934-828e-2c2fc7c82f28">

Fix was to follow the deprecation style in the same file:
```lua
compat.flatten = function(t)
  if vim.fn.has "nvim-0.11" == 1 then
    return vim.iter(t):flatten():totable()
  else
    return vim.tbl_flatten(t)
  end
end
```
This removes the error. All tests pass since functionality is the same.

Chose not to add to changelog since this seemed to fit with the line:
"- Add compatibility for NVIM 0.11"