### PR TITLE
Convert paths to strings before concatenating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed finding backlinks with URL-encoded path references.
 - Fixed using templates with frontmatter when `disable_frontmatter` is set to true. Previously the frontmatter would be removed when the template was inserted, now it will be kept unchanged.
 - Add compatibility for NVIM 0.11
+- Fixed warnings when renaming a note using dry-run
 
 ## [v3.7.12](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.12) - 2024-05-02
 

--- a/lua/obsidian/commands/rename.lua
+++ b/lua/obsidian/commands/rename.lua
@@ -155,7 +155,7 @@ return function(client, data)
         end
         vim.fn.delete(tostring(cur_note_path))
       else
-        log.info("Dry run: saving current buffer as '" .. new_note_path .. "' and removing old file")
+        log.info("Dry run: saving current buffer as '" .. tostring(new_note_path) .. "' and removing old file")
       end
     else
       -- For the non-current buffer the best we can do is delete the buffer (we've already saved it above)
@@ -164,7 +164,13 @@ return function(client, data)
         quietly(vim.cmd.bdelete, cur_note_bufnr)
         cur_note_path:rename(new_note_path)
       else
-        log.info("Dry run: removing buffer '" .. cur_note_path .. "' and renaming file to '" .. new_note_path .. "'")
+        log.info(
+          "Dry run: removing buffer '"
+            .. tostring(cur_note_path)
+            .. "' and renaming file to '"
+            .. tostring(new_note_path)
+            .. "'"
+        )
       end
     end
   else
@@ -172,7 +178,7 @@ return function(client, data)
     if not dry_run then
       cur_note_path:rename(new_note_path)
     else
-      log.info("Dry run: renaming file '" .. cur_note_path .. "' to '" .. new_note_path .. "'")
+      log.info("Dry run: renaming file '" .. tostring(cur_note_path) .. "' to '" .. tostring(new_note_path) .. "'")
     end
   end
 
@@ -184,7 +190,7 @@ return function(client, data)
     if not dry_run then
       cur_note:save()
     else
-      log.info("Dry run: updating frontmatter of '" .. new_note_path .. "'")
+      log.info("Dry run: updating frontmatter of '" .. tostring(new_note_path) .. "'")
     end
   end
 


### PR DESCRIPTION
## Description
When renaming a note, paths are logged. These paths are table values and cannot be concatenated without first being converted to strings.

## How to test
Simply run `:ObsidianRename new-name --dry-run`

These errors should not appear anymore:
```
Do you want to continue? [Y/n] Error executing Lua callback: ...nvim/lazy/obsidian.nvim/lua/obsidian/commands/rename.lua:157: attempt to concatenate local 'ne
w_note_path' (a table value)
stack traceback:
        ...nvim/lazy/obsidian.nvim/lua/obsidian/commands/rename.lua:157: in function 'func'
        ...e/nvim/lazy/obsidian.nvim/lua/obsidian/commands/init.lua:68: in function <...e/nvim/lazy/obsidian.nvim/lua/obsidian/commands/init.lua:67>
```


PS: This is my first PR in Lua, I am gladly open for improvements. 