### PR TITLE
Add config option `search_max_lines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added config option `ui.max_file_length` to disable the UI for files with more than this many lines. Defaults to 5000.
+- Added config option `search_max_lines` (defaults to 1000) for controlling the max number of lines read from disk from note files during certain searches.
 
 ## [v3.7.13](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.13) - 2024-05-31
 

--- a/README.md
+++ b/README.md
@@ -418,6 +418,9 @@ This is a complete list of all of the options that can be passed to `require("ob
   sort_by = "modified",
   sort_reversed = true,
 
+  -- Set the maximum number of lines to read from notes on disk when performing certain searches.
+  search_max_lines = 1000,
+
   -- Optional, determines how certain commands open notes. The valid options are:
   -- 1. "current" (the default) - to always open in the current window
   -- 2. "vsplit" - to open in a vertical split if there's not already a vertical split

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1080,7 +1080,7 @@ Client.find_tags_async = function(self, term, callback, opts)
   ---@param path obsidian.Path
   ---@return { [1]: obsidian.Note, [2]: {[1]: integer, [2]: integer}[] }
   local load_note = function(path)
-    local note, contents = Note.from_file_with_contents_async(path)
+    local note, contents = Note.from_file_with_contents_async(path, { max_lines = self.opts.search_max_lines or 1000 })
     return { note, search.find_code_blocks(contents) }
   end
 

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -27,6 +27,7 @@ local config = {}
 ---@field open_app_foreground boolean|?
 ---@field sort_by obsidian.config.SortBy|?
 ---@field sort_reversed boolean|?
+---@field search_max_lines integer
 ---@field open_notes_in obsidian.config.OpenStrategy
 ---@field ui obsidian.config.UIOpts | table<string, any>
 ---@field attachments obsidian.config.AttachmentsOpts
@@ -59,6 +60,7 @@ config.ClientOpts.default = function()
     open_app_foreground = false,
     sort_by = "modified",
     sort_reversed = true,
+    search_max_lines = 1000,
     open_notes_in = "current",
     ui = config.UIOpts.default(),
     attachments = config.AttachmentsOpts.default(),


### PR DESCRIPTION
Adds a configuration option `search_max_lines` to control the maximum number of lines read from disk when performing certain searches. For an example of when you might want to tune this, see #609.