### PR TITLE
Make searching for notes by filename case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Searching for notes by file name is case insensitive.
+
 ## [v3.7.14](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.14) - 2024-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
 - Searching for notes by file name is case insensitive.
 
 ## [v3.7.14](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.14) - 2024-06-04

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -421,7 +421,13 @@ Client._search_iter_async = function(self, term, search_opts, find_opts)
     on_exit
   )
 
-  search.find_async(self.dir, term, self:_prepare_search_opts(find_opts), on_find_match, on_exit)
+  search.find_async(
+    self.dir,
+    term,
+    self:_prepare_search_opts(find_opts, { ignore_case = true }),
+    on_find_match,
+    on_exit
+  )
 
   return function()
     while cmds_done < 2 do

--- a/lua/obsidian/search.lua
+++ b/lua/obsidian/search.lua
@@ -407,6 +407,10 @@ M.build_find_cmd = function(path, term, opts)
     additional_opts[#additional_opts + 1] = term
   end
 
+  if opts.ignore_case then
+    additional_opts[#additional_opts + 1] = "--glob-case-insensitive"
+  end
+
   if path ~= nil and path ~= "." then
     if opts.escape_path then
       path = assert(vim.fn.fnameescape(tostring(path)))


### PR DESCRIPTION
I have a note named "Rob Snyder.md". When I tried to link to it with cmp like "[[rob " the note wasn't found.

After this change the note is found. Note that `ignore_case` will set the `--ignore-case` flag in the rg command. However that flag is ignored and instead `--glob-case-insensitive` is what affects results.