### PR TITLE
feat(backlinks): make relative to root links searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added relative to root markdown links as search pattern for backlinks.
+
 ## [v3.7.14](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.7.14) - 2024-06-04
 
 ### Added

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1297,10 +1297,14 @@ Client.find_backlinks_async = function(self, note, callback, opts)
           search_terms[#search_terms + 1] = string.format("[[%s|", ref)
           -- Markdown link without anchor/block.
           search_terms[#search_terms + 1] = string.format("(%s)", ref)
+          -- Markdown link without anchor/block and is relative to root.
+          search_terms[#search_terms + 1] = string.format("(/%s)", ref)
           -- Wiki links with anchor/block.
           search_terms[#search_terms + 1] = string.format("[[%s#", ref)
           -- Markdown link with anchor/block.
           search_terms[#search_terms + 1] = string.format("(%s#", ref)
+          -- Markdown link with anchor/block and is relative to root.
+          search_terms[#search_terms + 1] = string.format("(/%s#", ref)
         elseif anchor then
           -- Note: Obsidian allow a lot of different forms of anchor links, so we can't assume
           -- it's the standardized form here.
@@ -1308,11 +1312,15 @@ Client.find_backlinks_async = function(self, note, callback, opts)
           search_terms[#search_terms + 1] = string.format("[[%s#", ref)
           -- Markdown link with anchor.
           search_terms[#search_terms + 1] = string.format("(%s#", ref)
+          -- Markdown link with anchor and is relative to root.
+          search_terms[#search_terms + 1] = string.format("(/%s#", ref)
         elseif block then
           -- Wiki links with block.
           search_terms[#search_terms + 1] = string.format("[[%s#%s", ref, block)
           -- Markdown link with block.
           search_terms[#search_terms + 1] = string.format("(%s#%s", ref, block)
+          -- Markdown link with block and is relative to root.
+          search_terms[#search_terms + 1] = string.format("(/%s#%s", ref, block)
         end
       end
     end


### PR DESCRIPTION
This pull request adds relative to root markdown links as a backlink search item.

closes #625 