### PR TITLE
Update README.md and doc/obsidian.txt to show example of how to implement follow URL on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ This is a complete list of all of the options that can be passed to `require("ob
     -- Open the URL in the default web browser.
     vim.fn.jobstart({"open", url})  -- Mac OS
     -- vim.fn.jobstart({"xdg-open", url})  -- linux
+    -- vim.cmd(':silent exec "!start ' .. url .. '"') -- Windows
   end,
 
   -- Optional, set to true if you use the Obsidian Advanced URI plugin.

--- a/doc/obsidian.txt
+++ b/doc/obsidian.txt
@@ -453,6 +453,7 @@ carefully and customize it to your needs:
         -- Open the URL in the default web browser.
         vim.fn.jobstart({"open", url})  -- Mac OS
         -- vim.fn.jobstart({"xdg-open", url})  -- linux
+        -- vim.cmd(':silent exec "!start ' .. url .. '"') -- Windows
       end,
     
       -- Optional, set to true if you use the Obsidian Advanced URI plugin.

--- a/doc/obsidian.txt
+++ b/doc/obsidian.txt
@@ -453,7 +453,6 @@ carefully and customize it to your needs:
         -- Open the URL in the default web browser.
         vim.fn.jobstart({"open", url})  -- Mac OS
         -- vim.fn.jobstart({"xdg-open", url})  -- linux
-        -- vim.cmd(':silent exec "!start ' .. url .. '"') -- Windows
       end,
     
       -- Optional, set to true if you use the Obsidian Advanced URI plugin.


### PR DESCRIPTION
I use Windows and found a workaround for using the following URL function.  I am new to nvim configs with Lua and I tried other methods using jobstart, but on my Windows system, none of them worked. So, I had to resort to silently executing a cmd command. After doing this, I think it can be helpful to be added to the readme.md and docs/obsidian.txt to help future users. Thanks.