### PR TITLE
Corrects trivial typo on ObsidianPasteImg's description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed an edge case with collecting backlinks.
+- Fixed typo in `ObsidianPasteImg`'s command description
 
 ## [v3.9.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.9.0) - 2024-07-11
 

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -179,7 +179,7 @@ M.register(
 
 M.register(
   "ObsidianPasteImg",
-  { opts = { nargs = "?", complete = "file", desc = "Paste and image from the clipboard" } }
+  { opts = { nargs = "?", complete = "file", desc = "Paste an image from the clipboard" } }
 )
 
 M.register(


### PR DESCRIPTION
Corrects a trivial typo in the description of the `ObsidianPasteImg` command.