### PR TITLE
fix: deal with lack of opts.attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an edge case with collecting backlinks.
 - Fixed typo in `ObsidianPasteImg`'s command description
+- Fixed the case when `opts.attachments` is `nil`.
 
 ## [v3.9.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.9.0) - 2024-07-11
 

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -208,6 +208,9 @@ config.ClientOpts.normalize = function(opts, defaults)
   end
 
   if opts.image_name_func then
+    if opts.attachments == nil then
+      opts.attachments = {}
+    end
     opts.attachments.img_name_func = opts.image_name_func
     opts.image_name_func = nil
   end


### PR DESCRIPTION
Without this fix, it causes an error when `opts.attachments` does not exist.