### PR TITLE
fix(type): makes client opts optional

### DIFF
--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -4,34 +4,34 @@ local util = require "obsidian.util"
 local config = {}
 
 ---@class obsidian.config.ClientOpts
----@field dir string|?
----@field workspaces obsidian.workspace.WorkspaceSpec[]|?
----@field log_level integer
----@field notes_subdir string|?
----@field templates obsidian.config.TemplateOpts
----@field new_notes_location obsidian.config.NewNotesLocation
----@field note_id_func (fun(title: string|?): string)|?
----@field note_path_func (fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path)|?
----@field wiki_link_func (fun(opts: {path: string, label: string, id: string|?}): string)
----@field markdown_link_func (fun(opts: {path: string, label: string, id: string|?}): string)
----@field preferred_link_style obsidian.config.LinkStyle
----@field follow_url_func fun(url: string)|?
----@field follow_img_func fun(img: string)|?
----@field note_frontmatter_func (fun(note: obsidian.Note): table)|?
----@field disable_frontmatter (fun(fname: string?): boolean)|boolean|?
----@field completion obsidian.config.CompletionOpts
----@field mappings obsidian.config.MappingOpts
----@field picker obsidian.config.PickerOpts
----@field daily_notes obsidian.config.DailyNotesOpts
----@field use_advanced_uri boolean|?
----@field open_app_foreground boolean|?
----@field sort_by obsidian.config.SortBy|?
----@field sort_reversed boolean|?
----@field search_max_lines integer
----@field open_notes_in obsidian.config.OpenStrategy
----@field ui obsidian.config.UIOpts | table<string, any>
----@field attachments obsidian.config.AttachmentsOpts
----@field callbacks obsidian.config.CallbackConfig
+---@field dir? string|?
+---@field workspaces? obsidian.workspace.WorkspaceSpec[]|?
+---@field log_level? integer
+---@field notes_subdir? string|?
+---@field templates? obsidian.config.TemplateOpts
+---@field new_notes_location? obsidian.config.NewNotesLocation
+---@field note_id_func? (fun(title: string|?): string)|?
+---@field note_path_func? (fun(spec: { id: string, dir: obsidian.Path, title: string|? }): string|obsidian.Path)|?
+---@field wiki_link_func? (fun(opts: {path: string, label: string, id: string|?}): string)
+---@field markdown_link_func? (fun(opts: {path: string, label: string, id: string|?}): string)
+---@field preferred_link_style? obsidian.config.LinkStyle
+---@field follow_url_func? fun(url: string)|?
+---@field follow_img_func? fun(img: string)|?
+---@field note_frontmatter_func? (fun(note: obsidian.Note): table)|?
+---@field disable_frontmatter? (fun(fname: string?): boolean)|boolean|?
+---@field completion? obsidian.config.CompletionOpts
+---@field mappings? obsidian.config.MappingOpts
+---@field picker? obsidian.config.PickerOpts
+---@field daily_notes? obsidian.config.DailyNotesOpts
+---@field use_advanced_uri? boolean|?
+---@field open_app_foreground? boolean|?
+---@field sort_by? obsidian.config.SortBy|?
+---@field sort_reversed? boolean|?
+---@field search_max_lines? integer
+---@field open_notes_in? obsidian.config.OpenStrategy
+---@field UI? obsidian.config.UIOpts | table<string, any>
+---@field attachments? obsidian.config.AttachmentsOpts
+---@field callbacks? obsidian.config.CallbackConfig
 config.ClientOpts = {}
 
 --- Get defaults.


### PR DESCRIPTION
Please do correct me if I'm wrong, but obsidian.nvim does have a default for all of these fields, so all of this can be optional.

Otherwise if the following occur:

```lua
    ---@type obsidian.config.ClientOpts
    opts = {
    	...partially update some fields
    }
```

Diagnostic will show 

<img width="1920" alt="Screenshot 2024-08-16 at 12 32 18" src="https://github.com/user-attachments/assets/78db6e80-6d07-4978-a236-6cdd88a7030a">

