### PR TITLE
feat(templates): provide note to custom variable substitution functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.
 - Added better handling for undefined template fields, which will now be prompted for.
+- Added the related `Note` to the custom variable substitution functions.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -712,19 +712,33 @@ Date created: 2023-03-01-Wed
 
 above the cursor position.
 
-You can also define custom template substitutions with the configuration field `templates.substitutions`. For example, to automatically substitute the template variable `{{yesterday}}` when inserting a template, you could add this to your config:
+You can also define custom template substitutions with the configuration field `templates.substitutions`.
+
+For example, to automatically substitute the template variable `{{watermark}}`, `{{yesterday}}`, `{{normalized_title}}`
+when inserting a template, you could add this to your config:
 
 ```lua
 {
 -- other fields ...
 templates = {
   substitutions = {
+    watermark = "Obsidian.nvim",
     yesterday = function()
       return os.date("%Y-%m-%d", os.time() - 86400)
-    end
+    end,
+    ---Format `id` field of `Note` to a more human-readable string.
+    ---For an `id` "17823674-My-note-title", it will returns "My note title"
+    ---@param note obsidian.Note
+    normalized_title = function(note)
+        return note.id:gsub("%d+-?", ""):gsub("-", " ")
+    end,
   }
 }
 ```
+
+> [!NOTE]
+> You could set substitution keys to `string` or `function`.
+> The `function` receives the related `Note` as the first parameter.
 
 ### Usage outside of a workspace or vault
 

--- a/lua/obsidian/templates.lua
+++ b/lua/obsidian/templates.lua
@@ -83,7 +83,7 @@ M.substitute_template_variables = function(text, client, note)
       if type(subst) == "string" then
         value = subst
       else
-        value = subst()
+        value = subst(note)
         -- cache the result
         methods[key] = value
       end

--- a/test/obsidian/templates_spec.lua
+++ b/test/obsidian/templates_spec.lua
@@ -19,8 +19,14 @@ local tmp_client = function()
 end
 
 describe("templates.substitute_template_variables()", function()
+  ---@type obsidian.Client
+  local client
+
+  before_each(function()
+    client = tmp_client()
+  end)
+
   it("should substitute built-in variables", function()
-    local client = tmp_client()
     local text = "today is {{date}} and the title of the note is {{title}}"
     assert.equal(
       string.format("today is %s and the title of the note is %s", os.date "%Y-%m-%d", "FOO"),
@@ -28,18 +34,43 @@ describe("templates.substitute_template_variables()", function()
     )
   end)
 
-  it("should substitute custom variables", function()
-    local client = tmp_client()
-    client.opts.templates.substitutions = {
-      weekday = function()
-        return "Monday"
-      end,
-    }
-    local text = "today is {{weekday}}"
-    assert.equal("today is Monday", templates.substitute_template_variables(text, client, Note.new("foo", {}, {})))
+  describe("when substituting custom variable", function()
+    it("should substitute using a string", function()
+      client.opts.templates.substitutions = {
+        weekday = "Monday",
+      }
+      local text = "today is {{weekday}}"
+      assert.equal("today is Monday", templates.substitute_template_variables(text, client, Note.new("foo", {}, {})))
 
-    -- Make sure the client opts has not been modified.
-    assert.equal(1, vim.tbl_count(client.opts.templates.substitutions))
-    assert.equal("function", type(client.opts.templates.substitutions.weekday))
+      -- Make sure the client opts has not been modified.
+      assert.equal(1, vim.tbl_count(client.opts.templates.substitutions))
+      assert.equal("string", type(client.opts.templates.substitutions.weekday))
+    end)
+
+    it("should substitute using a function", function()
+      client.opts.templates.substitutions = {
+        weekday = function()
+          return "Monday"
+        end,
+      }
+      local text = "today is {{weekday}}"
+      assert.equal("today is Monday", templates.substitute_template_variables(text, client, Note.new("foo", {}, {})))
+
+      -- Make sure the client opts has not been modified.
+      assert.equal(1, vim.tbl_count(client.opts.templates.substitutions))
+      assert.equal("function", type(client.opts.templates.substitutions.weekday))
+    end)
+
+    it("should substitute using values from the note", function()
+      client.opts.templates.substitutions = {
+        ---@param note obsidian.Note
+        id_uppercase = function(note)
+          return string.upper(note.id)
+        end,
+      }
+
+      local text = "formatted id: {{id_uppercase}}"
+      assert.equal("formatted id: FOO", templates.substitute_template_variables(text, client, Note.new("foo", {}, {})))
+    end)
   end)
 end)


### PR DESCRIPTION
## Descrition

Provide the `Note` related with the template to the custom variable substitution function. This helps to define custom variables that require `Note` data.

### Examples

#### Uppercase the note ID

```lua
-- ...
templates = {
  substitutions = {
    ---@param note obsidian.Note
    uppercase_id = function(note)
      return note.id:upper()
    end,
  }
}
-- ...
```

#### Set a custom title based on the note ID

```lua
-- ...
templates = {
  substitutions = {
    ---Format `id` field of `Note` to a more human-readable string.
    ---For an `id` "17823674-My-note-title", it will returns "My note title"
    ---@param note obsidian.Note
    normalized_title = function(note)
        return note.id:gsub("%d+-?", ""):gsub("-", " ")
    end,
  }
}
-- ...
```

This will make the template variables more flexible, e.g.:

```md
<!-- This template -->
# {{normalized_title}}

<!-- ...will be replaced by -->
# My note title
```

```md
<!-- Instead of this template -->
# {{id}}

<!-- ...that will be replaced to -->
# 17823674-My-note-title
```

## Changes

- Provide `Note` when executing substitution functions.
- Update test related with the substitution functions.
- Add change to `CHANGELOG.md`.