### PR TITLE
Add option to generate Obsidian-compatible wiki links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.
 - Added better handling for undefined template fields, which will now be prompted for.
+- You can now set `wiki_link_func` to `use_name_only` to generate wiki links in the format `[[Foo]]`, ensuring compatibility with the Obsidian desktop app.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ This is a complete list of all of the options that can be passed to `require("ob
   --  * "prepend_note_id", e.g. '[[foo-bar|Foo Bar]]'
   --  * "prepend_note_path", e.g. '[[foo-bar.md|Foo Bar]]'
   --  * "use_path_only", e.g. '[[foo-bar.md]]'
+  --  * "use_name_only", e.g, '[[foo-bar]]'
   -- Or you can set it to a function that takes a table of options and returns a string, like this:
   wiki_link_func = function(opts)
     return require("obsidian.util").wiki_link_id_prefix(opts)

--- a/doc/obsidian.txt
+++ b/doc/obsidian.txt
@@ -393,7 +393,6 @@ carefully and customize it to your needs:
       --  * "prepend_note_id", e.g. '[[foo-bar|Foo Bar]]'
       --  * "prepend_note_path", e.g. '[[foo-bar.md|Foo Bar]]'
       --  * "use_path_only", e.g. '[[foo-bar.md]]'
-      --  * "use_name_only", e.g. '[[foo-bar]]'
       -- Or you can set it to a function that takes a table of options and returns a string, like this:
       wiki_link_func = function(opts)
         return require("obsidian.util").wiki_link_id_prefix(opts)

--- a/doc/obsidian.txt
+++ b/doc/obsidian.txt
@@ -393,6 +393,7 @@ carefully and customize it to your needs:
       --  * "prepend_note_id", e.g. '[[foo-bar|Foo Bar]]'
       --  * "prepend_note_path", e.g. '[[foo-bar.md|Foo Bar]]'
       --  * "use_path_only", e.g. '[[foo-bar.md]]'
+      --  * "use_name_only", e.g. '[[foo-bar]]'
       -- Or you can set it to a function that takes a table of options and returns a string, like this:
       wiki_link_func = function(opts)
         return require("obsidian.util").wiki_link_id_prefix(opts)

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -148,6 +148,8 @@ config.ClientOpts.normalize = function(opts, defaults)
     opts.wiki_link_func = util.wiki_link_path_only
   elseif opts.wiki_link_func == "use_alias_only" then
     opts.wiki_link_func = util.wiki_link_alias_only
+  elseif opts.wiki_link_func == "use_name_only" then
+    opts.wiki_link_func = util.wiki_link_name_only
   elseif type(opts.wiki_link_func) == "string" then
     error(string.format("invalid option '%s' for 'wiki_link_func'", opts.wiki_link_func))
   end

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -1027,7 +1027,7 @@ end
 util.wiki_link_name_only = function(opts)
   local header_or_block = ""
   if opts.anchor then
-    header_or_block = opts.anchor.anchor
+    header_or_block = string.format("#%s", opts.anchor.header)
   elseif opts.block then
     header_or_block = string.format("#%s", opts.block.id)
   end

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -1025,20 +1025,17 @@ end
 ---@param opts { path: string, label: string, id: string|integer|?, anchor: obsidian.note.HeaderAnchor|?, block: obsidian.note.Block|? }
 ---@return string
 util.wiki_link_name_only = function(opts)
-  local anchor = ""
-  local header = ""
+  local header_or_block = ""
   if opts.anchor then
-    anchor = opts.anchor.anchor
-    header = util.format_anchor_label(opts.anchor)
+    header_or_block = opts.anchor.anchor
   elseif opts.block then
-    anchor = "#" .. opts.block.id
-    header = "#" .. opts.block.id
+    header_or_block = string.format("#%s", opts.block.id)
   end
   local name = opts.path:gsub("%.md", "")
   if opts.label ~= name then
-    return string.format("[[%s%s|%s%s]]", name, anchor, opts.label, header)
+    return string.format("[[%s%s|%s]]", name, header_or_block, opts.label)
   else
-    return string.format("[[%s%s]]", name, anchor)
+    return string.format("[[%s%s]]", name, header_or_block)
   end
 end
 

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -1024,6 +1024,26 @@ end
 
 ---@param opts { path: string, label: string, id: string|integer|?, anchor: obsidian.note.HeaderAnchor|?, block: obsidian.note.Block|? }
 ---@return string
+util.wiki_link_name_only = function(opts)
+  local anchor = ""
+  local header = ""
+  if opts.anchor then
+    anchor = opts.anchor.anchor
+    header = util.format_anchor_label(opts.anchor)
+  elseif opts.block then
+    anchor = "#" .. opts.block.id
+    header = "#" .. opts.block.id
+  end
+  local name = opts.path:gsub("%.md", "")
+  if opts.label ~= name then
+    return string.format("[[%s%s|%s%s]]", name, anchor, opts.label, header)
+  else
+    return string.format("[[%s%s]]", name, anchor)
+  end
+end
+
+---@param opts { path: string, label: string, id: string|integer|?, anchor: obsidian.note.HeaderAnchor|?, block: obsidian.note.Block|? }
+---@return string
 util.wiki_link_id_prefix = function(opts)
   local anchor = ""
   local header = ""

--- a/test/obsidian/util_spec.lua
+++ b/test/obsidian/util_spec.lua
@@ -367,7 +367,7 @@ end)
 
 describe("util.wiki_link_name_only()", function()
   it("should work without an anchor link", function()
-    assert.equals("[[123-foo]]", util.wiki_link_name_only { path = "123-foo.md", id = "123-foo", label = "Foo" })
+    assert.equals("[[123-foo|Foo]]", util.wiki_link_name_only { path = "123-foo.md", id = "123-foo", label = "Foo" })
   end)
 
   it("should work with an anchor link", function()

--- a/test/obsidian/util_spec.lua
+++ b/test/obsidian/util_spec.lua
@@ -365,6 +365,24 @@ describe("util.wiki_link_path_only()", function()
   end)
 end)
 
+describe("util.wiki_link_name_only()", function()
+  it("should work without an anchor link", function()
+    assert.equals("[[123-foo]]", util.wiki_link_name_only { path = "123-foo.md", id = "123-foo", label = "Foo" })
+  end)
+
+  it("should work with an anchor link", function()
+    assert.equals(
+      "[[123-foo#heading]]",
+      util.wiki_link_name_only {
+        path = "123-foo.md",
+        id = "123-foo",
+        label = "Foo",
+        anchor = { anchor = "#heading", header = "Heading", level = 1, line = 1 },
+      }
+    )
+  end)
+end)
+
 describe("util.markdown_link()", function()
   it("should work without an anchor link", function()
     assert.equals("[Foo](123-foo.md)", util.markdown_link { path = "123-foo.md", id = "123-foo", label = "Foo" })


### PR DESCRIPTION
This PR adds a new option `use_name_only` for the `wiki_link_func` setting that generates links in the `[[Foo]]` format. This ensures compatibility with the Obsidian desktop app, which might not recognize links in the `[[alias]]` format.

#### Changes made:

* Added the `use_name_only` option to `wiki_link_func`, which generates links using the filename and the relative path without the extension.
* This configuration can be customized to better fit the folder structure of each user.
* The `use_name_only` option differs from the existing `use_alias_only`, as `use_alias_only` might not work correctly with the desktop version if the alias is not identical to the filename.

#### Reason for the contribution:

The default autocompletion function generated links that were not recognized by the Obsidian desktop app, making note navigation more difficult. With this function, links are compatible and easy to use in both `obsidian.nvim` and the Obsidian app.
