### PR TITLE
Add :ObsidianToggleCheckboxReverse command to loop through checklist marks in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.
 - Added better handling for undefined template fields, which will now be prompted for.
+- Added  :ObsidianToggleCheckboxReverse  command. This command goes in reverse order compared to the :ObsidianToggleCheckbox.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ _Keep in mind this plugin is not meant to replace Obsidian, but to complement it
 
 - `:ObsidianToggleCheckbox` to cycle through checkbox options.
 
+- `:ObsidianToggleCheckboxReverse` to cycle through checkbox options in a reverse order.
+
 - `:ObsidianNewFromTemplate [TITLE]` to create a new note from a template in the templates folder. Selecting from a list using your preferred picker.
   This command has one optional argument: the title of the new note.
 

--- a/lua/obsidian/commands/init.lua
+++ b/lua/obsidian/commands/init.lua
@@ -4,6 +4,7 @@ local iter = require("obsidian.itertools").iter
 local command_lookups = {
   ObsidianCheck = "obsidian.commands.check",
   ObsidianToggleCheckbox = "obsidian.commands.toggle_checkbox",
+  ObsidianToggleCheckboxReverse = "obsidian.commands.toggle_checkbox_reverse",
   ObsidianToday = "obsidian.commands.today",
   ObsidianYesterday = "obsidian.commands.yesterday",
   ObsidianTomorrow = "obsidian.commands.tomorrow",
@@ -169,6 +170,8 @@ M.register("ObsidianLinks", { opts = { nargs = 0, desc = "Collect all links with
 M.register("ObsidianFollowLink", { opts = { nargs = "?", desc = "Follow reference or link under cursor" } })
 
 M.register("ObsidianToggleCheckbox", { opts = { nargs = 0, desc = "Toggle checkbox" } })
+
+M.register("ObsidianToggleCheckboxReverse", { opts = { nargs = 0, desc = "Toggle checkbox in reverse order" } })
 
 M.register("ObsidianWorkspace", { opts = { nargs = "?", desc = "Check or switch workspace" } })
 

--- a/lua/obsidian/commands/toggle_checkbox_reverse.lua
+++ b/lua/obsidian/commands/toggle_checkbox_reverse.lua
@@ -1,0 +1,10 @@
+local toggle_checkbox = require("obsidian.util").toggle_checkbox
+
+---@param client obsidian.Client
+return function(client)
+  local checkboxes = vim.tbl_keys(client.opts.ui.checkboxes)
+  table.sort(checkboxes, function(a, b)
+    return (client.opts.ui.checkboxes[a].order or 1000) > (client.opts.ui.checkboxes[b].order or 1000)
+  end)
+  toggle_checkbox(checkboxes)
+end


### PR DESCRIPTION
This PR adds a new command to toggle checkboxes in a reverse order, useful when you are using more than 1 checklist mark option.

### Reason for the contribution:
I have 4 (+ empty) different checklist marks and I wanted the ability to toggle a checkbox (i.e. the last option of the checkbox list) into `DONE` in a single keystroke.