### PR TITLE
feat: add an UI option to ignore conceal warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added `opts.ui.ignore_conceal_warn` option to ignore conceal-related warnings.
+
 ### Added
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.

--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ This is a complete list of all of the options that can be passed to `require("ob
   -- This requires you have `conceallevel` set to 1 or 2. See `:help conceallevel` for more details.
   ui = {
     enable = true,  -- set to false to disable all additional syntax features
+    ignore_conceal_warn = false, -- set to true to disable conceallevel specific warning
     update_debounce = 200,  -- update delay after a text change (in milliseconds)
     max_file_length = 5000,  -- disable UI features for files with more than this many lines
     -- Define how various check-boxes are displayed

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -407,6 +407,7 @@ end
 ---@class obsidian.config.UIOpts
 ---
 ---@field enable boolean
+---@field ignore_conceal_warn boolean
 ---@field update_debounce integer
 ---@field max_file_length integer|?
 ---@field checkboxes table<string, obsidian.config.CheckboxSpec>
@@ -438,6 +439,7 @@ config.UIOpts = {}
 config.UIOpts.default = function()
   return {
     enable = true,
+    ignore_conceal_warn = false,
     update_debounce = 200,
     max_file_length = 5000,
     checkboxes = {

--- a/lua/obsidian/ui.lua
+++ b/lua/obsidian/ui.lua
@@ -625,7 +625,7 @@ M.setup = function(workspace, ui_opts)
     callback = function()
       local conceallevel = vim.opt_local.conceallevel:get()
 
-      if conceallevel < 1 or conceallevel > 2 then
+      if (conceallevel < 1 or conceallevel > 2) and not ui_opts.ignore_conceal_warn then
         log.warn_once(
           "Obsidian additional syntax features require 'conceallevel' to be set to 1 or 2, "
             .. "but you have 'conceallevel' set to '%s'.\n"


### PR DESCRIPTION
In https://github.com/epwalsh/obsidian.nvim/issues/286#issuecomment-2048334358 it was suggested that a new config could be added to specifically not warn if the conceal level is 0 and the UI is enabled.

This commit does this and guard against the conceal warning when the option is set.

cc https://github.com/epwalsh/obsidian.nvim/issues/492