### PR TITLE
feature: allow grouping daily notes by date.

### DIFF
--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -117,7 +117,14 @@ Client.set_workspace = function(self, workspace, opts)
   end
 
   if self.opts.daily_notes.folder ~= nil then
-    local daily_notes_subdir = self.dir / self.opts.daily_notes.folder
+    ---@type string
+    local folder = self.opts.daily_notes.folder
+
+    ---@diagnostic disable-next-line: need-check-nil
+    if folder:find "%%" then
+      folder = tostring(os.date(folder, os.time()))
+    end
+    local daily_notes_subdir = self.dir / folder
     daily_notes_subdir:mkdir { parents = true, exists_ok = true }
   end
 
@@ -1914,9 +1921,16 @@ Client.daily_note_path = function(self, datetime)
   local path = Path:new(self.dir)
 
   if self.opts.daily_notes.folder ~= nil then
-    ---@type obsidian.Path
+    ---@type string
+    local folder = self.opts.daily_notes.folder
+
+    ---@diagnostic disable-next-line: need-check-nil
+    if folder:find "%%" then
+      folder = tostring(os.date(folder, datetime))
+    end
+
     ---@diagnostic disable-next-line: assign-type-mismatch
-    path = path / self.opts.daily_notes.folder
+    path = path / folder
   elseif self.opts.notes_subdir ~= nil then
     ---@type obsidian.Path
     ---@diagnostic disable-next-line: assign-type-mismatch


### PR DESCRIPTION
I was trying to find a way to group the daily notes by year and month.
After looking at the codebase I found that it's possible to do so by templating the `opts.daily_notes.folder` and allow adding template variables for datetime in lua.

example: 
`lazy.nvim` configs
```lua
return {
  "epwalsh/obsidian.nvim",
...
  opts = {
    ...
    daily_notes = {
      folder = "notes/dailies/%Y/%B"
      ...
    },
    ...
  },
...
}
```

output: 
```text
notes
└── dailies
    └── 2024
        ├── December
        │   ├── 2024-12-01.md
        │   ├── 2024-12-02.md
        │   ├── 2024-12-03.md
```

