### PR TITLE
Mark before jumping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.
 - Added better handling for undefined template fields, which will now be prompted for.
+- The follow-link function now marks the current position in the jump list before moving.
 
 ### Changed
 

--- a/lua/obsidian/commands/follow_link.lua
+++ b/lua/obsidian/commands/follow_link.lua
@@ -4,6 +4,6 @@ return function(client, data)
   if data.args and string.len(data.args) > 0 then
     opts.open_strategy = data.args
   end
-
+  vim.cmd [[normal! m']]
   client:follow_link_async(nil, opts)
 end


### PR DESCRIPTION
When I follow a link, the location before jumping should be added to the jump list, because it is a large motion. With this, it is possible to go back with Ctrl-O right after following a link.