### PR TITLE
Add support for saving images to relative directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.
 - Added better handling for undefined template fields, which will now be prompted for.
+- Added Support for saving pasted images to a relative directory based on the currently opened file's path, when attachments.relative_dir is set to true.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,10 @@ This is a complete list of all of the options that can be passed to `require("ob
     -- You can always override this per image by passing a full path to the command instead of just a filename.
     img_folder = "assets/imgs",  -- This is the default
 
+    -- Set to true if you want newly added images to be saved in a subdirectory under current file's directory.
+    -- If enabled and your current file is under vault/file_dir, newly pasted images will be saved under vault/file_dir/{img_folder}
+    relative_dir = false,  -- This is the default
+
     -- Optional, customize the default name or prefix when pasting images via `:ObsidianPasteImg`.
     ---@return string
     img_name_func = function()

--- a/lua/obsidian/commands/paste_img.lua
+++ b/lua/obsidian/commands/paste_img.lua
@@ -18,6 +18,7 @@ return function(client, data)
   local path = paste_img {
     fname = data.args,
     default_dir = img_folder,
+    relative_dir = client.opts.attachments.relative_dir,
     default_name = default_name,
     should_confirm = client.opts.attachments.confirm_img_paste,
   }

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -472,6 +472,7 @@ end
 ---@class obsidian.config.AttachmentsOpts
 ---
 ---@field img_folder string Default folder to save images to, relative to the vault root.
+---@field relative_dir boolean Whether newly added attachments should be saved in a relative subfolder
 ---@field img_name_func (fun(): string)|?
 ---@field img_text_func fun(client: obsidian.Client, path: obsidian.Path): string
 ---@field confirm_img_paste boolean Whether to confirm the paste or not. Defaults to true.
@@ -481,6 +482,7 @@ config.AttachmentsOpts = {}
 config.AttachmentsOpts.default = function()
   return {
     img_folder = "assets/imgs",
+    relative_dir = false,
     ---@param client obsidian.Client
     ---@param path obsidian.Path the absolute path to the image file
     ---@return string

--- a/lua/obsidian/img_paste.lua
+++ b/lua/obsidian/img_paste.lua
@@ -84,11 +84,12 @@ local function save_clipboard_image(path)
   end
 end
 
----@param opts { fname: string|?, default_dir: obsidian.Path|string|?, default_name: string|?, should_confirm: boolean|? }|? Options.
+---@param opts { fname: string|?, default_dir: obsidian.Path|string|?, relative_dir: boolean|?, default_name: string|?, should_confirm: boolean|? }|? Options.
 ---
 --- Options:
 ---  - `fname`: The filename.
 ---  - `default_dir`: The default directory to put the image file in.
+---  - `relative_dir`: Save in a subdirectory under current directory.
 ---  - `default_name`: The default name to assign the image.
 ---  - `should_confirm`: Prompt to confirm before proceeding.
 ---
@@ -139,7 +140,12 @@ M.paste_img = function(opts)
     -- fname is a full path
     path = path:resolve()
   elseif opts.default_dir ~= nil then
-    path = (Path.new(opts.default_dir) / path):resolve()
+    if opts.relative_dir then
+      local opened_file_dir = Path.new(path.buffer()):parent()
+      path = (opened_file_dir / opts.default_dir.name / path):resolve()
+    else
+      path = (Path.new(opts.default_dir) / path):resolve()
+    end
   else
     log.err "'default_dir' must be provided"
     return


### PR DESCRIPTION
Adding support for dynamic new location for new images.
If attachments.relative_dir is set to true, expect the following behavior:
- If your current file is under vault/file_dir, newly pasted images will be saved under vault/file_dir/{img_folder}

This replicates the following configuration:
![image](https://github.com/user-attachments/assets/99f280dd-29a8-4aa3-a5bb-8da7331e2422)

This pull request resolves #279 