### PR TITLE
added option to not add title as header automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.
 - Added better handling for undefined template fields, which will now be prompted for.
+- Added a `title_as_header` config option to decide whether or not note.title is added as the first header (`# note.title`).
+
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,11 @@ This is a complete list of all of the options that can be passed to `require("ob
   -- Either 'wiki' or 'markdown'.
   preferred_link_style = "wiki",
 
+  -- Optional, boolean.
+  -- `false` indicates that you don't want obsidian.nvim to manage add `note.title` as the first
+  -- header.
+  title_as_header = true,
+
   -- Optional, boolean or a function that takes a filename and returns a boolean.
   -- `true` indicates that you don't want obsidian.nvim to manage frontmatter.
   disable_frontmatter = false,

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -1831,6 +1831,8 @@ Client.write_note = function(self, note, opts)
   local path = assert(opts.path or note.path, "A path must be provided")
   path = Path.new(path)
 
+  local title_as_header = require("obsidian").get_client().opts.title_as_header
+
   ---@type string
   local verb
   if path:is_file() then
@@ -1845,6 +1847,10 @@ Client.write_note = function(self, note, opts)
   local frontmatter = nil
   if self.opts.note_frontmatter_func ~= nil then
     frontmatter = self.opts.note_frontmatter_func(note)
+  end
+
+  if not title_as_header then
+    note.title = nil
   end
 
   note:save {

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -18,6 +18,7 @@ local config = {}
 ---@field follow_url_func fun(url: string)|?
 ---@field follow_img_func fun(img: string)|?
 ---@field note_frontmatter_func (fun(note: obsidian.Note): table)|?
+---@field title_as_header boolean|?
 ---@field disable_frontmatter (fun(fname: string?): boolean)|boolean|?
 ---@field completion obsidian.config.CompletionOpts
 ---@field mappings obsidian.config.MappingOpts
@@ -51,6 +52,7 @@ config.ClientOpts.default = function()
     preferred_link_style = config.LinkStyle.wiki,
     follow_url_func = nil,
     note_frontmatter_func = nil,
+    title_as_header = true,
     disable_frontmatter = false,
     completion = config.CompletionOpts.default(),
     mappings = config.MappingOpts.default(),

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -754,6 +754,8 @@ Note.save_to_buffer = function(self, opts)
 
   local cur_buf_note = Note.from_buffer(bufnr)
 
+  local title_as_header = require("obsidian").get_client().opts.title_as_header
+
   ---@type string[]
   local new_lines
   if opts.insert_frontmatter ~= false then
@@ -762,7 +764,7 @@ Note.save_to_buffer = function(self, opts)
     new_lines = {}
   end
 
-  if util.buffer_is_empty(bufnr) and self.title ~= nil then
+  if util.buffer_is_empty(bufnr) and self.title ~= nil and title_as_header then
     table.insert(new_lines, "# " .. self.title)
   end
 


### PR DESCRIPTION
This feature is intended to resolve #716, I have added a new config option titled `title_as_header`, by default `true` which is the same as current settings.

If set to `false` it does not set the `note.title` as the first header when creating a note from a reference or ObsidianNew.