### PR TITLE
add `opts.app_path` to set Obsidian.app path on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.
 - Added better handling for undefined template fields, which will now be prompted for.
+- Added `opts.app_path` to set the path to the Obsidian.app (MacOS only)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ This is a complete list of all of the options that can be passed to `require("ob
   -- https://github.com/Vinzent03/obsidian-advanced-uri
   use_advanced_uri = false,
 
+  -- Optional, set to the path of Obsidian.app (MacOS only)
+  app_path = "/path/to/Obsidian.app",
+
   -- Optional, set to true to force ':ObsidianOpen' to bring the app to the foreground.
   open_app_foreground = false,
 

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -42,9 +42,9 @@ local function open_in_app(client, path)
   elseif this_os == util.OSType.Darwin then
     cmd = "open"
     if client.opts.open_app_foreground then
-      args = { "-a", client.opts.app_path or "/Applications/Obsidian.app", uri }
+      args = { "-a", "\""  .. client.opts.app_path .. "\"" or "/Applications/Obsidian.app", uri }
     else
-      args = { "-a", client.opts.app_path or "/Applications/Obsidian.app", "--background", uri }
+      args = { "-a", "\"" .. client.opts.app_path .. "\"" or "/Applications/Obsidian.app", "--background", uri }
     end
   else
     log.err("open command does not support OS type '" .. this_os .. "'")

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -42,9 +42,9 @@ local function open_in_app(client, path)
   elseif this_os == util.OSType.Darwin then
     cmd = "open"
     if client.opts.open_app_foreground then
-      args = { "-a", "/Applications/Obsidian.app", uri }
+      args = { "-a", client.opts.app_path or "/Applications/Obsidian.app", uri }
     else
-      args = { "-a", "/Applications/Obsidian.app", "--background", uri }
+      args = { "-a", client.opts.app_path or "/Applications/Obsidian.app", "--background", uri }
     end
   else
     log.err("open command does not support OS type '" .. this_os .. "'")

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -42,9 +42,9 @@ local function open_in_app(client, path)
   elseif this_os == util.OSType.Darwin then
     cmd = "open"
     if client.opts.open_app_foreground then
-      args = { "-a", "\""  .. client.opts.app_path .. "\"" or "/Applications/Obsidian.app", uri }
+      args = { "-a", client.opts.app_path ~= nil and "\"" ..client.opts.app_path.."\"" or "/Applications/Obsidian.app", uri }
     else
-      args = { "-a", "\"" .. client.opts.app_path .. "\"" or "/Applications/Obsidian.app", "--background", uri }
+      args = { "-a", client.opts.app_path ~= nil and "\""..client.opts.app_path.."\"" or "/Applications/Obsidian.app", "--background", uri }
     end
   else
     log.err("open command does not support OS type '" .. this_os .. "'")

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -24,6 +24,7 @@ local config = {}
 ---@field picker obsidian.config.PickerOpts
 ---@field daily_notes obsidian.config.DailyNotesOpts
 ---@field use_advanced_uri boolean|?
+---@field app_path string|?
 ---@field open_app_foreground boolean|?
 ---@field sort_by obsidian.config.SortBy|?
 ---@field sort_reversed boolean|?
@@ -57,6 +58,7 @@ config.ClientOpts.default = function()
     picker = config.PickerOpts.default(),
     daily_notes = config.DailyNotesOpts.default(),
     use_advanced_uri = nil,
+    app_path = nil,
     open_app_foreground = false,
     sort_by = "modified",
     sort_reversed = true,


### PR DESCRIPTION
This adds a new option that lets users specify the path to Obsidian.app on MacOS.

Justification: Some people keep their apps in subdirectories for organization reasons.  I do it because I manage most of my apps with `nix-darwin` which puts apps in a non-standard subdirectory.