### PR TITLE
Added `opts.wayland` option for Wayland blurry work-around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `opts.follow_img_func` option for customizing how to handle image paths.
 - Added better handling for undefined template fields, which will now be prompted for.
+- Added `opts.wayland` option for Wayland blurry work-around.
 
 ### Changed
 

--- a/lua/obsidian/commands/open.lua
+++ b/lua/obsidian/commands/open.lua
@@ -31,6 +31,9 @@ local function open_in_app(client, path)
   local run_in_shell = true
   if this_os == util.OSType.Linux or this_os == util.OSType.FreeBSD then
     cmd = "xdg-open"
+    if client.opts.wayland == true then
+      cmd = "obsidian --enable-features=UseOzonePlatform --ozone-platform=wayland"
+    end
     args = { uri }
   elseif this_os == util.OSType.Wsl then
     cmd = "wsl-open"

--- a/lua/obsidian/config.lua
+++ b/lua/obsidian/config.lua
@@ -32,6 +32,7 @@ local config = {}
 ---@field ui obsidian.config.UIOpts | table<string, any>
 ---@field attachments obsidian.config.AttachmentsOpts
 ---@field callbacks obsidian.config.CallbackConfig
+---@field wayland boolean|?
 config.ClientOpts = {}
 
 --- Get defaults.
@@ -65,6 +66,7 @@ config.ClientOpts.default = function()
     ui = config.UIOpts.default(),
     attachments = config.AttachmentsOpts.default(),
     callbacks = config.CallbackConfig.default(),
+    wayland = false,
   }
 end
 


### PR DESCRIPTION
Modified `open.lua` to allow calling Obsidian directly with flags, instead of relying on `xdg-open`.