### PR TITLE
Fix issue not remove Chinese Anchor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,12 @@ concurrency:
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
       - main
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   style:
@@ -57,7 +57,7 @@ jobs:
 
         include:
           - os: ubuntu-latest
-            nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
+            nvim_url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-x86_64.tar.gz
             packages: luarocks ripgrep
             manager: sudo apt-get
 
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install requirements
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an edge case with collecting backlinks.
 - Fixed typo in `ObsidianPasteImg`'s command description
 - Fixed the case when `opts.attachments` is `nil`.
+- Fixed `util.strip_anchor_links` to properly handle Chinese/non-ASCII characters in anchor links.
 
 ## [v3.9.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.9.0) - 2024-07-11
 

--- a/lua/obsidian/client.lua
+++ b/lua/obsidian/client.lua
@@ -850,6 +850,7 @@ end
 ---@param link string|?
 ---@param opts { open_strategy: obsidian.config.OpenStrategy|? }|?
 Client.follow_link_async = function(self, link, opts)
+  print("follow_link_async: ", link)
   opts = opts and opts or {}
 
   self:resolve_link_async(link, function(...)

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -1125,7 +1125,7 @@ util.get_icon = function(path)
 end
 
 -- We are very loose here because obsidian allows pretty much anything
-util.ANCHOR_LINK_PATTERN = "#[%w%d][^#]*"
+util.ANCHOR_LINK_PATTERN = "#[^%s]+"
 
 util.BLOCK_PATTERN = "%^[%w%d][%w%d-]*"
 
@@ -1139,11 +1139,12 @@ util.strip_anchor_links = function(line)
   local anchor
 
   while true do
-    local anchor_match = string.match(line, util.ANCHOR_LINK_PATTERN .. "$")
-    if anchor_match then
+    local start_pos, end_pos = string.find(line, util.ANCHOR_LINK_PATTERN .. "$")
+    if start_pos then
+      local anchor_match = string.sub(line, start_pos, end_pos)
       anchor = anchor or ""
       anchor = anchor_match .. anchor
-      line = string.sub(line, 1, -anchor_match:len() - 1)
+      line = string.sub(line, 1, start_pos - 1)
     else
       break
     end

--- a/lua/obsidian/util.lua
+++ b/lua/obsidian/util.lua
@@ -1238,8 +1238,14 @@ util.standardize_anchor = function(anchor)
   anchor = string.lower(anchor)
   -- Replace whitespace with "-".
   anchor = string.gsub(anchor, "%s", "-")
-  -- Remove every non-alphanumeric character.
-  anchor = string.gsub(anchor, "[^#%w_-]", "")
+  -- Remove every non-alphanumeric character except Chinese characters.
+  -- Keep:
+  -- - # (for anchor links)
+  -- - word characters (%w)
+  -- - underscore (_)
+  -- - hyphen (-)
+  -- - Chinese characters (UTF-8 byte ranges)
+  anchor = string.gsub(anchor, "[^#%w_%-\xe4-\xef\x80-\xbf]", "")
   return anchor
 end
 


### PR DESCRIPTION
The function `util.strip_anchor_links` not remove the Chinese anchor. 
For example, The link [[AAA#中文]], after the process of `util.strip_anchor_links`  the result should be [[AAA]]. 
But in the current repo, the link will stay origin as [[AAA#中文]]
So I make the fix.
