### PR TITLE
fix yaml quoting for colon-ending aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an edge case with collecting backlinks.
 - Fixed typo in `ObsidianPasteImg`'s command description
 - Fixed the case when `opts.attachments` is `nil`.
+- Fixed YAML frontmatter serialization for aliases ending with a colon.
 
 ## [v3.9.0](https://github.com/epwalsh/obsidian.nvim/releases/tag/v3.9.0) - 2024-07-11
 

--- a/lua/obsidian/note.lua
+++ b/lua/obsidian/note.lua
@@ -523,7 +523,7 @@ Note.from_lines = function(lines, path, opts)
               else
                 log.warn(
                   "Invalid alias value found in frontmatter for "
-                    .. path
+                    .. tostring(path)
                     .. ". Expected string, found "
                     .. type(alias)
                     .. "."

--- a/lua/obsidian/yaml/init.lua
+++ b/lua/obsidian/yaml/init.lua
@@ -24,6 +24,9 @@ local should_quote = function(s)
   -- Check if it has a colon followed by whitespace.
   elseif string.find(s, ": ", 1, true) then
     return true
+  -- Check if it ends with a colon.
+  elseif string.match(s, ":$") then
+    return true
   -- Check if it's an empty string.
   elseif s == "" or string.match(s, "^[%s]+$") then
     return true

--- a/test/obsidian/client_spec.lua
+++ b/test/obsidian/client_spec.lua
@@ -160,7 +160,7 @@ describe("Client:parse_title_id_path()", function()
     with_tmp_client(function(client)
       client.opts.note_path_func = function(_)
         return "foo-bar-123.md"
-      end
+      end;
 
       (client.dir / "notes"):mkdir { exist_ok = true }
 

--- a/test/obsidian/note_spec.lua
+++ b/test/obsidian/note_spec.lua
@@ -1,8 +1,10 @@
 ---@diagnostic disable: invisible
 
 local Note = require "obsidian.note"
+local Path = require "obsidian.path"
 local util = require "obsidian.util"
 local async = require "plenary.async"
+local iter = require("obsidian.itertools").iter
 
 describe("Note.new()", function()
   it("should be able to be initialize directly", function()
@@ -181,6 +183,21 @@ describe("Note.from_file()", function()
     assert.equals(note.aliases[2], "Detective Green")
     assert.equals(note.aliases[3], "Mandy")
     assert.equals(note.title, "Detective")
+  end)
+
+  it("should not fail to warn when an invalid alias is parsed with a Path object", function()
+    local ok = pcall(
+      Note.from_lines,
+      iter {
+        "---",
+        "id: test",
+        "aliases:",
+        "  - Summary:",
+        "---",
+      },
+      Path.new "test.md"
+    )
+    assert.is_true(ok)
   end)
 end)
 

--- a/test/obsidian/yaml/yaml_spec.lua
+++ b/test/obsidian/yaml/yaml_spec.lua
@@ -46,6 +46,13 @@ describe("obsidian.yaml.dumps", function()
   it("should otherwise quote strings with a colon followed by whitespace", function()
     assert.equals(yaml.dumps { a = "2023: a letter" }, [[a: "2023: a letter"]])
   end)
+  it("should quote strings that end with a colon", function()
+    assert.equals(
+      yaml.dumps { aliases = { "Summary:" } },
+      [[aliases:
+- "Summary:"]]
+    )
+  end)
   it("should quote strings that start with special characters", function()
     assert.equals(yaml.dumps { a = "& aaa" }, [[a: "& aaa"]])
     assert.equals(yaml.dumps { a = "! aaa" }, [[a: "! aaa"]])


### PR DESCRIPTION
### Current behaviour
If the top-most heading of your file ends in a colon, i.e.

Title:

Then, when obsidian.nvim adds the title the frontmatter, it includes the colon. This is bad news, because the entry in the frontmatter ending in a colon is interpreted as a table. Not good.

To make matters worse, the error which gets thrown is uninformative, so it can result in tears and desperation.

### Proposed new behaviour
If the top-most heading of your file ends in a colon, the title will be escaped in quotation marks before being added to the frontmatter. This stops it being interpreted as a table, and, still allows for searching of tags via obsidian.lua.

Furthermore, if it _does_ happen to be the case that you manually enter a tag in the frontmatter which _does_ end in a colon, you will get a helpful error warning, to prevent feeling bereft of direction.